### PR TITLE
Change root and config directory handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ dependencies = [
 name = "omni-led"
 version = "0.4.1"
 dependencies = [
+ "clap 4.5.23",
  "convert_case",
  "device_query",
  "dirs-next",

--- a/omni-led/Cargo.toml
+++ b/omni-led/Cargo.toml
@@ -15,6 +15,7 @@ name = "omni-led"
 path = "src/main.rs"
 
 [dependencies]
+clap = { version = "4.4", features = ["derive"] }
 convert_case = "0.8"
 device_query = "4.0"
 dirs-next = "2.0"

--- a/omni-led/src/constants/constants.rs
+++ b/omni-led/src/constants/constants.rs
@@ -16,66 +16,150 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use mlua::{Lua, chunk};
+use mlua::{Lua, UserData, UserDataFields};
 use std::path::PathBuf;
 use std::{
     env::consts::{EXE_EXTENSION, EXE_SUFFIX, OS},
     path::MAIN_SEPARATOR_STR,
 };
 
-use crate::create_table;
+use crate::common::user_data::{UniqueUserData, UserDataRef};
 
-pub struct Constants;
+#[derive(Debug)]
+pub struct Constants {
+    pub applications_dir: PathBuf,
+    pub config_dir: PathBuf,
+    pub data_dir: PathBuf,
+    pub exe_extension: &'static str,
+    pub exe_suffix: &'static str,
+    pub os: &'static str,
+    pub path_separator: &'static str,
+    pub root_dir: PathBuf,
+}
+
+const ENV_CONFIG_DIR: &str = "OMNILED_CONFIG_DIR";
 
 impl Constants {
-    pub fn load(lua: &Lua) {
-        let applications_dir = Self::applications_dir();
-        let applications_dir = applications_dir.to_str().unwrap();
+    pub fn load(lua: &Lua, config_path_override: Option<PathBuf>) {
+        Self::set_unique(
+            lua,
+            Self {
+                applications_dir: Self::exe_dir(),
+                config_dir: Self::resolve_config_dir(config_path_override),
+                data_dir: Self::root_dir().join("data"),
+                exe_extension: EXE_EXTENSION,
+                exe_suffix: EXE_SUFFIX,
+                os: OS,
+                path_separator: MAIN_SEPARATOR_STR,
+                root_dir: Self::root_dir(),
+            },
+        );
 
-        let platform = create_table!(lua, {
-            ApplicationsDir = $applications_dir,
-            ExeExtension = $EXE_EXTENSION,
-            ExeSuffix = $EXE_SUFFIX,
-            PathSeparator = $MAIN_SEPARATOR_STR,
-            Os = $OS,
+        // Logging isn't initialized yet...
+        std::println!("{:#?}", UserDataRef::<Self>::load(lua).get());
+    }
+
+    fn resolve_config_dir(root_override: Option<PathBuf>) -> PathBuf {
+        root_override.unwrap_or_else(|| match std::env::var(ENV_CONFIG_DIR) {
+            Ok(env_config_path) => PathBuf::from(env_config_path),
+            Err(_) => Self::root_dir().join("config"),
+        })
+    }
+
+    fn root_dir() -> PathBuf {
+        #[cfg(feature = "dev")]
+        let root = Self::exe_dir()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+
+        #[cfg(not(feature = "dev"))]
+        let root = Self::exe_dir().parent().unwrap().to_path_buf();
+
+        root
+    }
+
+    fn exe_dir() -> PathBuf {
+        std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf()
+    }
+}
+
+impl UniqueUserData for Constants {
+    fn identifier() -> &'static str {
+        "PLATFORM"
+    }
+}
+
+impl UserData for Constants {
+    fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
+        fields.add_field_method_get("ApplicationsDir", |_, constants| {
+            Ok(constants.applications_dir.to_str().unwrap().to_string())
         });
-        lua.globals().set("PLATFORM", platform).unwrap();
+        fields.add_field_method_get("ConfigDir", |_, constants| {
+            Ok(constants.config_dir.to_str().unwrap().to_string())
+        });
+        fields.add_field_method_get("ExeExtension", |_, constants| Ok(constants.exe_extension));
+        fields.add_field_method_get("ExeSuffix", |_, constants| Ok(constants.exe_suffix));
+        fields.add_field_method_get("Os", |_, constants| Ok(constants.os));
+        fields.add_field_method_get("PathSeparator", |_, constants| Ok(constants.path_separator));
+        fields.add_field_method_get("RootDir", |_, constants| {
+            Ok(constants.root_dir.to_str().unwrap().to_string())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    // Sync tests that access set and get the `ENV_CONFIG_DIR` variable so that they don't
+    // interfere with each other.
+    static ENV_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_test_lock() -> &'static Mutex<()> {
+        ENV_TEST_LOCK.get_or_init(|| Mutex::new(()))
     }
 
-    #[cfg(feature = "dev")]
-    pub fn root_dir() -> PathBuf {
-        let root_dir = PathBuf::from(".");
-        root_dir
+    #[test]
+    fn resolve_config_dir_with_path_override() {
+        let _guard = env_test_lock().lock().unwrap();
+
+        unsafe {
+            std::env::set_var(ENV_CONFIG_DIR, "[Env] OmniLED");
+        }
+
+        let root_dir = Constants::resolve_config_dir(Some(PathBuf::from("[CLI] OmniLED")));
+        assert_eq!(root_dir, PathBuf::from("[CLI] OmniLED"));
     }
 
-    #[cfg(not(feature = "dev"))]
-    pub fn root_dir() -> PathBuf {
-        let root_dir = dirs_next::config_dir().expect("Couldn't get default config directory");
-        let root_dir = root_dir.join("OmniLED");
-        root_dir
+    #[test]
+    fn resolve_config_dir_with_env_override() {
+        let _guard = env_test_lock().lock().unwrap();
+
+        unsafe {
+            std::env::set_var(ENV_CONFIG_DIR, "[Env] OmniLED");
+        }
+
+        let root_dir = Constants::resolve_config_dir(None);
+        assert_eq!(root_dir, PathBuf::from("[Env] OmniLED"));
     }
 
-    #[cfg(feature = "dev")]
-    pub fn applications_dir() -> PathBuf {
-        #[cfg(debug_assertions)]
-        const PATH: &str = "debug";
+    #[test]
+    fn resolve_config_dir_with_no_override() {
+        let _guard = env_test_lock().lock().unwrap();
 
-        #[cfg(not(debug_assertions))]
-        const PATH: &str = "release";
+        unsafe {
+            std::env::remove_var(ENV_CONFIG_DIR);
+        }
 
-        Self::root_dir().join("target").join(PATH)
-    }
-
-    #[cfg(not(feature = "dev"))]
-    pub fn applications_dir() -> PathBuf {
-        Self::root_dir().join("bin")
-    }
-
-    pub fn config_dir() -> PathBuf {
-        Self::root_dir().join("config")
-    }
-
-    pub fn data_dir() -> PathBuf {
-        Constants::root_dir().join("data")
+        let root_dir = Constants::resolve_config_dir(None);
+        assert_eq!(root_dir, Constants::root_dir().join("config"));
     }
 }

--- a/omni-led/src/devices/devices.rs
+++ b/omni-led/src/devices/devices.rs
@@ -25,13 +25,13 @@ use std::collections::hash_map::Entry;
 
 use crate::common::common::exec_file;
 use crate::common::user_data::{UniqueUserData, UserDataRef};
+use crate::constants::constants::Constants;
 use crate::create_table_with_defaults;
 use crate::devices::device::{Device, Settings};
 use crate::devices::emulator::emulator::EmulatorSettings;
 use crate::devices::steelseries_engine::steelseries_engine_device::SteelseriesEngineDeviceSettings;
 use crate::devices::usb_device;
 use crate::devices::usb_device::usb_device::USBDeviceSettings;
-use crate::settings::settings::get_full_path;
 
 type Constructor = fn(&Lua, Value) -> Box<dyn Device>;
 
@@ -93,7 +93,9 @@ impl Devices {
     }
 
     fn load_devices(lua: &Lua, env: Table) {
-        exec_file(lua, &get_full_path("devices.lua"), env).unwrap();
+        let constants = UserDataRef::<Constants>::load(lua);
+        let filename = constants.get().config_dir.join("devices.lua");
+        exec_file(lua, &filename, env).unwrap();
     }
 
     fn create_loaders(lua: &Lua) -> (HashMap<String, Constructor>, Table) {

--- a/omni-led/src/logging/logger.rs
+++ b/omni-led/src/logging/logger.rs
@@ -25,7 +25,7 @@ use mlua::{FromLua, Lua, UserData, UserDataMethods};
 use omni_led_derive::{FromLuaValue, UniqueUserData};
 use std::path::{Path, PathBuf};
 
-use crate::common::user_data::UniqueUserData;
+use crate::common::user_data::{UniqueUserData, UserDataRef};
 use crate::constants::constants::Constants;
 
 #[derive(Clone, Debug, UniqueUserData)]
@@ -35,18 +35,19 @@ pub struct Log {
 
 impl Log {
     pub fn load(lua: &Lua) {
-        let handle = init(Self::get_path());
+        let handle = init(Self::get_path(lua));
         let logger = Log { handle };
 
         Log::set_unique(lua, logger);
     }
 
-    pub fn set_level_filter(&self, level_filter: LevelFilter) {
-        change_log_level(&self.handle, Self::get_path(), level_filter.into());
+    pub fn set_level_filter(&self, lua: &Lua, level_filter: LevelFilter) {
+        change_log_level(&self.handle, Self::get_path(lua), level_filter.into());
     }
 
-    fn get_path() -> PathBuf {
-        Constants::data_dir().join("logging.log")
+    fn get_path(lua: &Lua) -> PathBuf {
+        let constants = UserDataRef::<Constants>::load(lua);
+        constants.get().data_dir.join("logging.log")
     }
 }
 

--- a/omni-led/src/script_handler/script_handler.rs
+++ b/omni-led/src/script_handler/script_handler.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 
 use crate::common::common::{KEY_VAL_TABLE, exec_file};
 use crate::common::user_data::{UniqueUserData, UserDataRef};
+use crate::constants::constants::Constants;
 use crate::create_table_with_defaults;
 use crate::devices::device::Device;
 use crate::devices::devices::{DeviceStatus, Devices};
@@ -36,7 +37,6 @@ use crate::renderer::animation::State;
 use crate::renderer::animation_group::AnimationGroup;
 use crate::renderer::renderer::Renderer;
 use crate::script_handler::script_data_types::{Widget, load_script_data_types};
-use crate::settings::settings::get_full_path;
 
 #[derive(UniqueUserData)]
 pub struct ScriptHandler {
@@ -91,7 +91,9 @@ impl ScriptHandler {
             .register("*".to_string(), event_handler)
             .unwrap();
 
-        exec_file(lua, &get_full_path("scripts.lua"), environment).unwrap();
+        let constants = UserDataRef::<Constants>::load(lua);
+        let filename = constants.get().config_dir.join("scripts.lua");
+        exec_file(lua, &filename, environment).unwrap();
     }
 
     pub fn set_value(&self, lua: &Lua, value_name: String, value: Value) -> mlua::Result<()> {

--- a/omni-led/src/server/server.rs
+++ b/omni-led/src/server/server.rs
@@ -81,8 +81,9 @@ impl PluginServer {
             timestamp,
         };
 
+        let constants = UserDataRef::<Constants>::load(lua);
         std::fs::write(
-            Constants::data_dir().join("server.json"),
+            constants.get().data_dir.join("server.json"),
             serde_json::to_string_pretty(&info).unwrap(),
         )
         .unwrap();


### PR DESCRIPTION
This PR introduces two main changes that provide more flexibility without breaking backward compatibility
- Root directory is now resolved as relative to `omni-led.exe` so that the installation directory can be changed.
- Config directory can now be overriten by `OMNILED_CONFIG_DIR` environment variable or `-c/--config-dir` flag.