### PR TITLE
Hotfix for animations that repeat once

### DIFF
--- a/omni-led/src/renderer/animation_group.rs
+++ b/omni-led/src/renderer/animation_group.rs
@@ -60,6 +60,12 @@ impl AnimationGroup {
         }
     }
 
+    pub fn reset(&mut self) {
+        for item in &mut self.items {
+            item.animation.reset();
+        }
+    }
+
     pub fn pre_sync(&mut self) {
         self.items.retain_mut(|item| {
             if self.new_data && self.keep_in_sync {

--- a/omni-led/src/renderer/renderer.rs
+++ b/omni-led/src/renderer/renderer.rs
@@ -70,13 +70,14 @@ impl Renderer {
     pub fn render(
         &mut self,
         animation_groups: &mut HashMap<usize, AnimationGroup>,
+        screen_changed: bool,
         size: Size,
         mut widgets: Vec<Widget>,
         memory_layout: MemoryLayout,
     ) -> (State, Buffer) {
         let mut buffer = Buffer::new(size, memory_layout);
 
-        self.calculate_animations(animation_groups, &mut widgets);
+        self.calculate_animations(animation_groups, &mut widgets, screen_changed);
 
         for operation in widgets {
             match operation {
@@ -267,6 +268,7 @@ impl Renderer {
         &mut self,
         animation_groups: &mut HashMap<usize, AnimationGroup>,
         widgets: &mut Vec<Widget>,
+        screen_changed: bool,
     ) {
         for widget in widgets {
             match widget {
@@ -318,8 +320,14 @@ impl Renderer {
             };
         }
 
-        for (_, group) in animation_groups {
+        for (_, group) in &mut *animation_groups {
             group.pre_sync();
+        }
+
+        if screen_changed {
+            for (_, group) in animation_groups {
+                group.reset();
+            }
         }
     }
 

--- a/omni-led/src/script_handler/script_handler.rs
+++ b/omni-led/src/script_handler/script_handler.rs
@@ -235,6 +235,7 @@ impl ScriptHandler {
             Some(to_update) => to_update,
             None => return Ok(()),
         };
+        let screen_changed = to_update != ctx.last_priority;
 
         let size = ctx.device.size(lua)?;
         let memory_layout = ctx.device.memory_layout(lua)?;
@@ -243,6 +244,7 @@ impl ScriptHandler {
         let output: LayoutData = ctx.layouts[to_update].layout.call(())?;
         let (animation_state, image) = renderer.render(
             &mut ctx.animation_groups[to_update],
+            screen_changed,
             size,
             output.widgets,
             memory_layout,


### PR DESCRIPTION
This will restart the animations with `Repeat::Once` when we switch back to render their layout. Without this, once the animation is finished, it always stays finished - even if we received a new event to draw a layout with such animation.