### PR TITLE
Script improvements

### DIFF
--- a/config/scripts.lua
+++ b/config/scripts.lua
@@ -11,7 +11,7 @@ local function volume()
             })
             table.insert(widgets, Widget.Text {
                 text = device.IsMuted and ' M ' or string.format("%3d", device.Volume),
-                font_size = FontSize.Value(24),
+                font_size = 24,
                 text_offset = 1,
                 position = { x = SCREEN.Width * 2 / 3, y = offset },
                 size = { width = SCREEN.Width / 3, height = SCREEN.Height / 2 },
@@ -78,14 +78,14 @@ local function clock()
         widgets = {
             Widget.Text {
                 text = string.format("%02d", CLOCK.Hours),
-                font_size = FontSize.Value(50),
+                font_size = 50,
                 text_offset = 1,
                 position = { x = 10, y = 0 },
                 size = { width = SCREEN.Width / 2, height = SCREEN.Height - 3 },
             },
             Widget.Text {
                 text = string.format("%02d", CLOCK.Minutes),
-                font_size = FontSize.Value(37),
+                font_size = 37,
                 text_offset = 1,
                 position = { x = SCREEN.Width / 2 + 3, y = 0 },
                 size = { width = 54, height = 26 },
@@ -126,7 +126,7 @@ local function weather()
             },
             Widget.Text {
                 text = value,
-                font_size = FontSize.Value(30),
+                font_size = 30,
                 text_offset = 1,
                 position = { x = SCREEN.Height, y = 0 },
                 size = { width = SCREEN.Height * 2, height = SCREEN.Height * 2 / 3 },

--- a/docs/scripting_reference.md
+++ b/docs/scripting_reference.md
@@ -13,6 +13,10 @@
 > >
 > > Default applications directory path.
 >
+> > `ConfigDir: string`
+> >
+> > Configuration directory path.
+>
 > > `ExeExtension: string`
 > >
 > > Extension used for executable files on current platform
@@ -42,12 +46,16 @@
 >
 > > `Os: string`
 > >
-> > Separator of path components on current platform
+> > Operating system name
 > >
 > > Values:
 > >
 > > - `"windows"` on Windows
 > > - `"linux"` on Linux
+>
+> > `RootDir: string`
+> >
+> > Root directory path
 
 ---
 
@@ -332,7 +340,7 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 >
 > > `Tiff`
 >
-> > `Webp`
+> > `WebP`
 
 ---
 
@@ -416,7 +424,7 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 
 > ### `emulator`
 >
-> Type: `fn(config: EmulatorConfig)`
+> Type: `fn(settings: EmulatorSettings)`
 >
 > Registers emulator with a given configuration.
 
@@ -436,17 +444,33 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 
 ---
 
+> ### `hid_device`
+>
+> Type: `fn(settings: HidDeviceSettings)`
+>
+> Registers HID USB device with a given configuration.
+
+---
+
 > ### `load_app`
 >
-> Type: `fn(path: string, args: [string])`
+> Type: `fn(config: Config)`
 >
-> Starts an application at `path` and passes the `args` as command line arguments.
+> Starts an application with the given configuration.
+
+---
+
+> ### `raw_usb_device`
+>
+> Type: `fn(settings: RawUsbDeviceSettings)`
+>
+> Registers raw USB device with a given configuration.
 
 ---
 
 > ### `steelseries_engine_device`
 >
-> Type: `fn(config: SteelSeriesEngineDeviceConfig)`
+> Type: `fn(settings: SteelSeriesEngineDeviceSettings)`
 >
 > Registers SteelSeries device with a given configuration.
 
@@ -454,17 +478,9 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 
 > ### `transform_data`
 >
-> Type: `fn(extra: ExtraBytes) -> fn(buffer: Buffer) -> [byte]`
+> Type: `fn(extra: ExtraBytes) -> (fn(buffer: Buffer) -> [byte])`
 >
 > Creates a tranform function that will add extra bytes to the rendered buffer.
-
----
-
-> ### `usb_device`
->
-> Type: `fn(config: USBDeviceConfig)`
->
-> Registers USB device with a given configuration.
 
 ## Objects
 
@@ -508,6 +524,34 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 > > `unregister: fn(self, handle: EventHandle)`
 > >
 > > Unregister from an event using a handle received when registering.
+
+---
+
+> ### `LOG`
+>
+> Type: `table`
+>
+> Provides logging functions for scripts.
+>
+> > `debug: fn(self, message: string)`
+> >
+> > Log a debug message
+>
+> > `error: fn(self, message: string)`
+> >
+> > Log an error message
+>
+> > `info: fn(self, message: string)`
+> >
+> > Log an info message
+>
+> > `trace: fn(self, message: string)`
+> >
+> > Log a trace message
+>
+> > `warn: fn(self, message: string)`
+> >
+> > Log a warning message
 
 ---
 
@@ -562,6 +606,22 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 > > Register a key combination and an action that will be executed when the combination is pressed.
 
 ## Types
+
+> ### `Config`
+>
+> Configuration for starting an application.
+>
+> > `path: string`
+> >
+> > Path to the executable.
+>
+> > `args: [string]`
+> >
+> > _Optional_. Default: `[]`.
+> >
+> > Command line arguments to pass to the executable.
+
+---
 
 > ### `EmulatorConfig`
 >
@@ -737,7 +797,7 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 
 ---
 
-> ### `SteelSeriesEngineDeviceConfig`
+> ### `SteelSeriesEngineDeviceSettings`
 >
 > Configuration for a device managed via SteelSeriesEngine.
 >
@@ -769,7 +829,7 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 > >
 > > Font weight to search for.
 >
-> > `streatch: FontStretch`
+> > `stretch: FontStretch`
 > >
 > > _Optional_. Default: `"Normal"`.
 > >
@@ -777,9 +837,56 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 
 ---
 
-> ### `USBDeviceConfig`
+> ### `HidDeviceSettings`
 >
-> Configuration for a USB device.
+> Configuration for an HID USB device.
+>
+> > `name: string`
+> >
+> > Unique name that identifies this configuration.
+>
+> > `screen_size: Size`
+> >
+> > Screen size of the HID device display.
+>
+> > `memory_layout: MemoryLayout`
+> >
+> > Memory layout of the renderer output.
+>
+> > `transform: fn(buffer: Buffer) -> [byte]`
+> >
+> > _Optional_. Default: No transformation of rendered data.
+> >
+> > Function that will transform rendered `buffer` into the final representation expected by the
+> > device. Data inside `buffer` is in a format specified by `memory_layout` field.
+>
+> > `hid_settings: HidSettings`
+> >
+> > HID-specific settings to identify and configure the USB device.
+
+---
+
+> ### `HidSettings`
+>
+> HID USB device settings.
+>
+> > `vendor_id: string`
+> >
+> > Device vendor ID.
+>
+> > `product_id: string`
+> >
+> > Device product ID.
+>
+> > `interface: string`
+> >
+> > USB interface number.
+
+---
+
+> ### `RawUsbDeviceSettings`
+>
+> Configuration for a raw USB device.
 >
 > > `name: string`
 > >
@@ -791,7 +898,7 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 >
 > > `memory_layout: MemoryLayout`
 > >
-> > Choose memory layout of the renderer output.
+> > Memory layout of the renderer output.
 >
 > > `transform: fn(buffer: Buffer) -> [byte]`
 > >
@@ -800,47 +907,47 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 > > Function that will transform rendered `buffer` into the final representation expected by the
 > > device. Data inside `buffer` is in a format specified by `memory_layout` field.
 >
-> > `usb_settings: USBSettings`
+> > `usb_settings: RawUsbSettings`
 > >
-> > Information to identify the USB device and settings for the device's screen USB interface.
+> > Raw USB settings to identify and configure the USB device.
 
 ---
 
-> ### `USBSettings`
+> ### `RawUsbSettings`
 >
-> Configuration for a USB device. All fields relate to the USB configuration.
+> Raw USB device settings.
 >
-> > `vendor_id: integer`
+> > `vendor_id: string`
 > >
-> > Device vendor ID, used to find the USB device.
+> > Device vendor ID.
 >
-> > `product_id: integer`
+> > `product_id: string`
 > >
-> > Device product ID, used to find the USB device.
+> > Device product ID.
 >
-> > `interface: integer`
+> > `interface: string`
 > >
-> > USB interface on which the OLED device will receive data.
+> > USB interface number.
 >
-> > `alternate_setting: integer`
+> > `alternate_setting: string`
 > >
-> > Alternate setting of the interface, used for displaying data on screen.
+> > Alternate setting.
 >
-> > `request_type: integer`
+> > `request_type: string`
 > >
-> > Request type used to send data to the interface on the device.
+> > USB control transfer request type.
 >
-> > `request: integer`
+> > `request: string`
 > >
-> > Request sent to the interface on the device.
+> > USB control transfer request ID.
 >
-> > `value: integer`
+> > `value: string`
 > >
-> > USB configuration value.
+> > USB control transfer value.
 >
-> > `index: integer`
+> > `index: string`
 > >
-> > USB configuration index.
+> > USB control transfer index.
 
 ## Widgets
 

--- a/docs/scripting_reference.md
+++ b/docs/scripting_reference.md
@@ -125,6 +125,52 @@ Given the following enum:
 > local variant_b = MyEnum.VariantB(7)
 > ```
 
+Enum variants marked with _implicit contruct_ can be used to implicitly construct an enum if it's a function argument:
+
+> Given:
+> 
+> > `MyEnum`
+> > > VariantA(string)
+> >
+> > > VariantB(string) _implicit construct_
+> >
+> > > VariantB(integer) _implicit construct_
+> 
+> and a function
+> 
+> > `fn some_fn(my_enum: MyEnum)`
+> 
+> These are all valid:
+> 
+> ```lua
+> -- constructs MyEnum.VariantA:
+> some_fn(MyEnum.VariantA('str')) 
+> 
+> -- constructs MyEnum.VariantB: 
+> some_fn(MyEnum.VariantB('str'))
+> some_fn('str')
+> 
+> -- constructs MyEnum.VariantC: 
+> some_fn(MyEnum.VariantC(1))
+> some_fn(1)
+> ```
+
+---
+
+> ### `EventKey`
+>
+> Used to match events in event handlers
+>
+> > `Regex(Regex)` _implicit construct_
+> >
+> > Match using regex
+> >
+> > `String(string)` _implicit construct_
+>
+> > Match the exact string
+
+---
+
 > ### `FontName`
 >
 > Font name to search for.
@@ -422,26 +468,48 @@ Given the following enum:
 
 ## Objects
 
+> ### `Buffer`
+>
+> Byte buffer that contains the rendered data.
+>
+> > `bytes`: `fn(self) -> [byte]`
+> >
+> > Get a flat array of bytes in a device-specific memory layout.
+
+---
+
+> ### `Regex`
+>
+> Used to check if a string matches a regex pattern
+>
+> > `new`: `fn(pattern: string) -> Regex`
+> >
+> > Creates a new regex object with a given pattern.
+> >
+> > This will return an error if pattern fails to compile.
+>
+> > `matches`: `fn(self, string: string) -> bool`
+> >
+> > Checks if `string` matches the regex pattern
+
+---
+
 > ### `EVENTS`
 >
 > Register callbacks for specific events. This, combined with script predicates, is useful when the
 > screen builder with default screen management doesn't quite cut it.
 >
-> > `register: fn(self, key: string, callback: fn(event: string, value: any)) -> EventHandle`
+> > `register: fn(self, key: EventKey, callback: fn(event: string, value: any)) -> EventHandle`
 > >
 > > Register a callback for any event. When the callback is triggered, the event name and its value
 > > will be passed as callback arguments.  
 > > Returns an EventHandle object that can be used to unsubscribe from the event.
-> >
-> > `register_regex: fn(self, regex_key: string, callback: fn(event: string, value: any)) -> EventHandle`
-> >
-> > Same as `EVENTS:register` but allows matching on regex instead of plain string.
-> >
-> > _Register for `event` `"*"` to match all events._
 >
 > > `unregister: fn(self, handle: EventHandle)`
 > >
 > > Unregister from an event using a handle received when registering.
+
+---
 
 > ### `SCREEN_BUILDER`
 >
@@ -494,16 +562,6 @@ Given the following enum:
 > > Register a key combination and an action that will be executed when the combination is pressed.
 
 ## Types
-
-> ### `Buffer`
->
-> Byte buffer that contains the rendered data.
->
-> > `bytes`: `fn() -> [byte]`
-> >
-> > Get a flat array of bytes in a device-specific memory layout.
-
----
 
 > ### `EmulatorConfig`
 >

--- a/docs/scripting_reference.md
+++ b/docs/scripting_reference.md
@@ -136,29 +136,29 @@ Given the following enum:
 Enum variants marked with _implicit contruct_ can be used to implicitly construct an enum if it's a function argument:
 
 > Given:
-> 
+>
 > > `MyEnum`
 > > > VariantA(string)
 > >
 > > > VariantB(string) _implicit construct_
 > >
 > > > VariantB(integer) _implicit construct_
-> 
+>
 > and a function
-> 
+>
 > > `fn some_fn(my_enum: MyEnum)`
-> 
+>
 > These are all valid:
-> 
+>
 > ```lua
 > -- constructs MyEnum.VariantA:
-> some_fn(MyEnum.VariantA('str')) 
-> 
-> -- constructs MyEnum.VariantB: 
+> some_fn(MyEnum.VariantA('str'))
+>
+> -- constructs MyEnum.VariantB:
 > some_fn(MyEnum.VariantB('str'))
 > some_fn('str')
-> 
-> -- constructs MyEnum.VariantC: 
+>
+> -- constructs MyEnum.VariantC:
 > some_fn(MyEnum.VariantC(1))
 > some_fn(1)
 > ```

--- a/docs/scripting_reference.md
+++ b/docs/scripting_reference.md
@@ -427,11 +427,15 @@ Given the following enum:
 > Register callbacks for specific events. This, combined with script predicates, is useful when the
 > screen builder with default screen management doesn't quite cut it.
 >
-> > `register: fn(self, event: string, callback: fn(event: string, value: any)) -> EventHandle`
+> > `register: fn(self, key: string, callback: fn(event: string, value: any)) -> EventHandle`
 > >
 > > Register a callback for any event. When the callback is triggered, the event name and its value
 > > will be passed as callback arguments.  
 > > Returns an EventHandle object that can be used to unsubscribe from the event.
+> >
+> > `register_regex: fn(self, regex_key: string, callback: fn(event: string, value: any)) -> EventHandle`
+> >
+> > Same as `EVENTS:register` but allows matching on regex instead of plain string.
 > >
 > > _Register for `event` `"*"` to match all events._
 >

--- a/docs/scripting_reference.md
+++ b/docs/scripting_reference.md
@@ -427,12 +427,17 @@ Given the following enum:
 > Register callbacks for specific events. This, combined with script predicates, is useful when the
 > screen builder with default screen management doesn't quite cut it.
 >
-> > `register: fn(self, event: string, callback: fn(event: string, value: any))`
+> > `register: fn(self, event: string, callback: fn(event: string, value: any)) -> EventHandle`
 > >
 > > Register a callback for any event. When the callback is triggered, the event name and its value
-> > will be passed as callback arguments.
+> > will be passed as callback arguments.  
+> > Returns an EventHandle object that can be used to unsubscribe from the event.
 > >
 > > _Register for `event` `"*"` to match all events._
+>
+> > `unregister: fn(self, handle: EventHandle)`
+> >
+> > Unregister from an event using a handle received when registering.
 
 > ### `SCREEN_BUILDER`
 >

--- a/docs/scripting_reference.md
+++ b/docs/scripting_reference.md
@@ -240,7 +240,7 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 > > Calculate font size to fit any text that doesn't have any "descendants". Useful for text that
 > > consists only of uppercase characters or numbers.
 >
-> > `Value(n: integer)`
+> > `Value(n: integer)` _implicit contruct_
 > >
 > > Set font size to be exactly `n`, regardless of widget size.
 

--- a/omni-led-derive/src/common.rs
+++ b/omni-led-derive/src/common.rs
@@ -1,6 +1,7 @@
 use proc_macro2::{Ident, TokenStream};
+use quote::ToTokens;
 use std::collections::HashMap;
-use syn::{Attribute, DataEnum, Token, Type};
+use syn::{Attribute, DataEnum, FieldsUnnamed, Token, Type};
 
 pub fn get_attribute_with_default_value(
     attributes: &mut HashMap<String, Option<TokenStream>>,
@@ -74,21 +75,33 @@ pub enum EnumFieldType {
 pub fn collect_enum_variants<'a, T: 'static, F: Fn(&Vec<Attribute>) -> T>(
     data: &'a DataEnum,
     get_enum_attributes: F,
-) -> Vec<(EnumFieldType, &'a Ident, T)> {
+) -> Vec<(EnumFieldType, &'a Ident, String, T)> {
     data.variants
         .iter()
         .map(|variant| match &variant.fields {
             syn::Fields::Named(_) => unimplemented!(),
-            syn::Fields::Unnamed(_) => (
+            syn::Fields::Unnamed(unnamed) => (
                 EnumFieldType::Unnamed,
                 &variant.ident,
+                get_type(unnamed),
                 get_enum_attributes(&variant.attrs),
             ),
             syn::Fields::Unit => (
                 EnumFieldType::Unit,
                 &variant.ident,
+                String::new(),
                 get_enum_attributes(&variant.attrs),
             ),
         })
         .collect()
+}
+
+fn get_type(unnamed: &FieldsUnnamed) -> String {
+    unnamed
+        .unnamed
+        .first()
+        .unwrap()
+        .ty
+        .to_token_stream()
+        .to_string()
 }

--- a/omni-led-derive/src/from_lua_value.rs
+++ b/omni-led-derive/src/from_lua_value.rs
@@ -152,7 +152,7 @@ fn generate_initializer(name: &Ident, data: &Data) -> (TokenStream, Option<Token
         Data::Enum(ref data) => {
             let fields = collect_enum_variants(data, get_enum_attributes);
 
-            let names = fields.iter().map(|(_, ident, attrs)| {
+            let names = fields.iter().map(|(_, ident, _ty, attrs)| {
                 let alias = attrs.alias.as_ref().map(|alias| quote! { #alias, });
                 quote! {
                     stringify!(#ident), #alias
@@ -165,14 +165,14 @@ fn generate_initializer(name: &Ident, data: &Data) -> (TokenStream, Option<Token
 
             for field in fields {
                 match field {
-                    (EnumFieldType::Unnamed, ident, _attrs) => {
+                    (EnumFieldType::Unnamed, ident, _ty, _attrs) => {
                         unnamed_initializers.push(quote! {
                             else if table.contains_key(stringify!(#ident))? {
                                 Ok(Self::#ident(table.get(stringify!(#ident))?))
                             }
                         });
                     }
-                    (EnumFieldType::Unit, ident, attrs) => {
+                    (EnumFieldType::Unit, ident, _ty, attrs) => {
                         let alias = attrs.alias.map(|alias| {
                             quote! {
                                 #alias => Ok(Self::#ident),

--- a/omni-led-derive/src/lua_enum.rs
+++ b/omni-led-derive/src/lua_enum.rs
@@ -61,7 +61,7 @@ fn generate_initializers(data: &Data) -> TokenStream {
                         };
                         initializers.push(initializer);
 
-                        if attrs.construct_from.is_some() {
+                        if attrs.implicit_construct.is_some() {
                             let constructor = quote! {
                                 .or_else(|_| user_data.borrow::<#ty>().map(|x| Self::#ident(x.clone())))
                             };
@@ -102,7 +102,7 @@ fn generate_constructors(data: &Data) -> (TokenStream, TokenStream) {
             for field in collect_enum_variants(data, get_enum_attributes) {
                 match field {
                     (EnumFieldType::Unnamed, ident, ty, attrs) => {
-                        if attrs.construct_from.is_some() {
+                        if attrs.implicit_construct.is_some() {
                             insert_constructor(&ty, ident, &mut lua_builtin, &mut userdata);
                         }
                     }
@@ -188,7 +188,7 @@ fn insert_constructor(
 
 struct EnumAttributes {
     alias: Option<TokenStream>,
-    construct_from: Option<TokenStream>,
+    implicit_construct: Option<TokenStream>,
 }
 
 fn get_enum_attributes(attributes: &Vec<Attribute>) -> EnumAttributes {
@@ -196,9 +196,9 @@ fn get_enum_attributes(attributes: &Vec<Attribute>) -> EnumAttributes {
 
     EnumAttributes {
         alias: get_attribute(&mut attributes, "alias"),
-        construct_from: get_attribute_with_default_value(
+        implicit_construct: get_attribute_with_default_value(
             &mut attributes,
-            "construct_from",
+            "implicit_construct",
             quote! {},
         ),
     }

--- a/omni-led-derive/src/lua_enum.rs
+++ b/omni-led-derive/src/lua_enum.rs
@@ -1,18 +1,24 @@
-use proc_macro2::TokenStream;
+use std::collections::{HashMap, hash_map::Entry};
+
+use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::{Attribute, Data, DeriveInput};
 
-use crate::common::{EnumFieldType, collect_enum_variants, get_attribute, parse_attributes};
+use crate::common::{
+    EnumFieldType, collect_enum_variants, get_attribute, get_attribute_with_default_value,
+    parse_attributes,
+};
 
 pub fn expand_lua_enum_derive(input: DeriveInput) -> proc_macro::TokenStream {
     let name = input.ident;
-    let initializer = generate_initializer(&input.data);
+    let table_initializer = generate_initializers(&input.data);
+    let (builtin, userdata) = generate_constructors(&input.data);
 
     let expanded = quote! {
         impl #name {
             pub fn set_lua_enum(lua: &mlua::Lua, env: &mlua::Table) -> mlua::Result<()> {
                 let table = lua.create_table()?;
-                #initializer
+                #table_initializer
                 env.set(stringify!(#name), table)?;
                 Ok(())
             }
@@ -21,9 +27,10 @@ pub fn expand_lua_enum_derive(input: DeriveInput) -> proc_macro::TokenStream {
         impl FromLua for #name {
              fn from_lua(value: mlua::Value, _lua: &mlua::Lua) -> mlua::Result<Self> {
                 match value {
+                    #builtin
                     mlua::Value::UserData(user_data) => {
-                        let value = user_data.borrow::<Self>()?;
-                        Ok(value.clone())
+                        user_data.borrow::<Self>().map(|v| v.clone())
+                            #userdata
                     }
                     other => Err(mlua::Error::runtime(format!(
                         "Expected {}, got {}", stringify!(#name), other.type_name()
@@ -36,24 +43,32 @@ pub fn expand_lua_enum_derive(input: DeriveInput) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(expanded)
 }
 
-fn generate_initializer(data: &Data) -> TokenStream {
+fn generate_initializers(data: &Data) -> TokenStream {
     match *data {
         Data::Struct(_) => panic!("Expected enum"),
         Data::Enum(ref data) => {
             let fields = collect_enum_variants(data, get_enum_attributes);
 
             let mut initializers = Vec::new();
+            let mut constructors = Vec::new();
             for field in fields {
                 match field {
-                    (EnumFieldType::Unnamed, ident, _attrs) => {
+                    (EnumFieldType::Unnamed, ident, ty, attrs) => {
                         let initializer = quote! {
                             table.set(stringify!(#ident), lua.create_function(|_, value| {
                                 Ok(Self::#ident(value))
                             })?)?;
                         };
                         initializers.push(initializer);
+
+                        if attrs.construct_from.is_some() {
+                            let constructor = quote! {
+                                .or_else(|_| user_data.borrow::<#ty>().map(|x| Self::#ident(x.clone())))
+                            };
+                            constructors.push(constructor);
+                        }
                     }
-                    (EnumFieldType::Unit, ident, attrs) => {
+                    (EnumFieldType::Unit, ident, _ty, attrs) => {
                         let initializer = quote! {
                             table.set(stringify!(#ident), Self::#ident)?;
                         };
@@ -78,8 +93,102 @@ fn generate_initializer(data: &Data) -> TokenStream {
     }
 }
 
+fn generate_constructors(data: &Data) -> (TokenStream, TokenStream) {
+    match *data {
+        Data::Struct(_) => panic!("Expected enum"),
+        Data::Enum(ref data) => {
+            let mut lua_builtin = HashMap::new();
+            let mut userdata = HashMap::new();
+            for field in collect_enum_variants(data, get_enum_attributes) {
+                match field {
+                    (EnumFieldType::Unnamed, ident, ty, attrs) => {
+                        if attrs.construct_from.is_some() {
+                            insert_constructor(&ty, ident, &mut lua_builtin, &mut userdata);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let lua_builtin = lua_builtin.into_values();
+            let userdata = userdata.into_values();
+
+            (quote! { #(#lua_builtin)* }, quote! { #(#userdata)* })
+        }
+        Data::Union(_) => panic!("Expected enum"),
+    }
+}
+
+fn insert_constructor(
+    ty: &str,
+    ident: &Ident,
+    builtin: &mut HashMap<String, TokenStream>,
+    userdata: &mut HashMap<String, TokenStream>,
+) {
+    let (lua_builtin, name, tt) = match ty {
+        "bool" => (
+            true,
+            "bool",
+            quote! { mlua::Value::Boolean(value) => Ok(Self::#ident(value)), },
+        ),
+        integer_ty @ ("i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "usize") => {
+            let integer_ty: TokenStream = integer_ty.parse().unwrap();
+            (
+                true,
+                "integer",
+                quote! {
+                    mlua::Value::Integer(value) =>
+                        Ok(Self::#ident(#integer_ty::try_from(value)
+                            .map_err(mlua::Error::external)?)),
+                },
+            )
+        }
+        number_ty @ ("f32" | "f64") => {
+            let number_ty: TokenStream = number_ty.parse().unwrap();
+            (
+                true,
+                "number",
+                quote! { mlua::Value::Number(value) => Ok(Self::#ident(value as #number_ty)), },
+            )
+        }
+        "String" => (
+            true,
+            "String",
+            quote! { mlua::Value::String(value) => Ok(Self::#ident(value.to_string_lossy())), },
+        ),
+        "Table" => (
+            true,
+            "Table",
+            quote! { mlua::Value::Table(value) => Ok(Self::#ident(value)), },
+        ),
+        "Function" => (
+            true,
+            "Function",
+            quote! { mlua::Value::Function(value) => Ok(Self::#ident(value)), },
+        ),
+        userdata => {
+            let userdata_ty: TokenStream = userdata.parse().unwrap();
+            (
+                false,
+                userdata,
+                quote! { .or_else(|_| user_data.borrow::<#userdata_ty>().map(|x| Self::#ident(x.clone()))) },
+            )
+        }
+    };
+
+    let map = if lua_builtin { builtin } else { userdata };
+    match map.entry(name.to_string()) {
+        Entry::Occupied(_) => {
+            panic!("Duplicate type detected: '{name}'");
+        }
+        Entry::Vacant(vacant_entry) => {
+            vacant_entry.insert(tt);
+        }
+    };
+}
+
 struct EnumAttributes {
     alias: Option<TokenStream>,
+    construct_from: Option<TokenStream>,
 }
 
 fn get_enum_attributes(attributes: &Vec<Attribute>) -> EnumAttributes {
@@ -87,5 +196,10 @@ fn get_enum_attributes(attributes: &Vec<Attribute>) -> EnumAttributes {
 
     EnumAttributes {
         alias: get_attribute(&mut attributes, "alias"),
+        construct_from: get_attribute_with_default_value(
+            &mut attributes,
+            "construct_from",
+            quote! {},
+        ),
     }
 }

--- a/omni-led-lib/src/common/common.rs
+++ b/omni-led-lib/src/common/common.rs
@@ -41,7 +41,8 @@ macro_rules! create_table_with_defaults {
             })
             .eval::<mlua::Table>()
             .unwrap();
-        crate::common::lua_enum::set_lua_enums($lua, &table);
+        crate::common::lua_register::set_lua_enums($lua, &table);
+        crate::common::lua_register::set_lua_types($lua, &table);
         table
     }};
 }

--- a/omni-led-lib/src/common/lua_register.rs
+++ b/omni-led-lib/src/common/lua_register.rs
@@ -1,13 +1,15 @@
 use mlua::{Lua, Table};
 
 use crate::{
+    common::lua_traits::LuaConstructor,
     devices::device::MemoryLayout,
     logging::logger::LevelFilter,
     renderer::font_selector::{FamilyName, FontSelector, Stretch, Style, Weight},
-    script_handler::script_data_types::{FontSize, ImageFormat, Repeat, Widget},
+    script_handler::script_data_types::{EventKey, FontSize, ImageFormat, Regex, Repeat, Widget},
 };
 
 pub fn set_lua_enums(lua: &Lua, env: &Table) {
+    EventKey::set_lua_enum(lua, env).unwrap();
     FamilyName::set_lua_enum(lua, env).unwrap();
     FontSelector::set_lua_enum(lua, env).unwrap();
     FontSize::set_lua_enum(lua, env).unwrap();
@@ -19,4 +21,8 @@ pub fn set_lua_enums(lua: &Lua, env: &Table) {
     Style::set_lua_enum(lua, env).unwrap();
     Weight::set_lua_enum(lua, env).unwrap();
     Widget::set_lua_enum(lua, env).unwrap();
+}
+
+pub fn set_lua_types(lua: &Lua, env: &Table) {
+    Regex::register_constructor(lua, env).unwrap();
 }

--- a/omni-led-lib/src/common/lua_traits.rs
+++ b/omni-led-lib/src/common/lua_traits.rs
@@ -1,0 +1,30 @@
+use mlua::{FromLuaMulti, Lua, Table, UserData, Value};
+
+pub trait LuaName {
+    const NAME: &str;
+}
+
+pub trait LuaConstructor: UserData + LuaName + 'static {
+    type Args: FromLuaMulti;
+
+    fn constructor(lua: &Lua, args: Self::Args) -> mlua::Result<Self>;
+
+    fn register_constructor(lua: &Lua, env: &Table) -> mlua::Result<()> {
+        let table = lua.create_table()?;
+        table.set("new", lua.create_function(Self::constructor)?)?;
+        env.set(Self::NAME, table)
+    }
+}
+
+pub trait FromUserdata: UserData + LuaName + Clone + 'static {
+    fn from_userdata(_lua: &Lua, value: Value) -> mlua::Result<Self> {
+        match value {
+            Value::UserData(userdata) => userdata.borrow::<Self>().map(|s| s.clone()),
+            other => Err(mlua::Error::FromLuaConversionError {
+                from: other.type_name(),
+                to: Self::NAME.to_string(),
+                message: None,
+            }),
+        }
+    }
+}

--- a/omni-led-lib/src/common/mod.rs
+++ b/omni-led-lib/src/common/mod.rs
@@ -1,3 +1,4 @@
 pub mod common;
-pub mod lua_enum;
+pub mod lua_register;
+pub mod lua_traits;
 pub mod user_data;

--- a/omni-led-lib/src/devices/usb_device/hid_device.rs
+++ b/omni-led-lib/src/devices/usb_device/hid_device.rs
@@ -51,7 +51,7 @@ impl Device for HidDevice {
             size: settings.screen_size,
             transform: settings.transform,
             handle,
-            layout: settings.memory_layout.unwrap(),
+            layout: settings.memory_layout,
         })
     }
 
@@ -87,7 +87,7 @@ pub struct HidDeviceSettings {
     pub screen_size: Size,
     pub hid_settings: HidSettings,
     pub transform: Option<Function>,
-    pub memory_layout: Option<MemoryLayout>,
+    pub memory_layout: MemoryLayout,
 }
 
 impl Settings for HidDeviceSettings {

--- a/omni-led-lib/src/devices/usb_device/raw_usb_device.rs
+++ b/omni-led-lib/src/devices/usb_device/raw_usb_device.rs
@@ -78,7 +78,7 @@ impl Device for RawUsbDevice {
             settings: settings.usb_settings.clone(),
             transform: settings.transform,
             handle,
-            layout: settings.memory_layout.unwrap(),
+            layout: settings.memory_layout,
         })
     }
 
@@ -136,9 +136,7 @@ pub struct RawUsbDeviceSettings {
     pub screen_size: Size,
     pub usb_settings: RawUsbSettings,
     pub transform: Option<Function>,
-    #[mlua(deprecated = memory_layout)]
-    pub memory_representation: Option<MemoryLayout>,
-    pub memory_layout: Option<MemoryLayout>,
+    pub memory_layout: MemoryLayout,
 }
 
 impl Settings for RawUsbDeviceSettings {

--- a/omni-led-lib/src/events/events.rs
+++ b/omni-led-lib/src/events/events.rs
@@ -1,13 +1,16 @@
-use mlua::{ErrorContext, Function, Lua, Table, UserData, UserDataMethods, Value};
-use omni_led_api::types::field::Field as FieldEntry;
+use mlua::{ErrorContext, Function, Lua, UserData, UserDataMethods, Value};
 use omni_led_api::types::{Field, field};
 use omni_led_derive::UniqueUserData;
-use std::hash::{DefaultHasher, Hash, Hasher};
 
 use crate::common::user_data::UniqueUserData;
 use crate::events::event_queue::Event;
+use crate::events::proto_to_lua::{get_cleanup_entries_metatable, proto_to_lua_value};
 use crate::keyboard::keyboard::{KeyboardEvent, KeyboardEventEventType};
-use crate::script_handler::script_data_types::ImageData;
+
+struct EventEntry {
+    event: String,
+    on_match: Function,
+}
 
 #[derive(UniqueUserData)]
 pub struct Events {
@@ -58,24 +61,15 @@ impl Events {
 
         self.dispatch_event(&current_key, &value)?;
 
-        match value {
-            Value::Table(table) => match table.metatable() {
-                Some(metatable) => {
-                    if !metatable.contains_key(CLEANUP_ENTRIES)? {
-                        return Err(mlua::Error::runtime(format!(
-                            "Unexpected metatable {:#?}",
-                            metatable
-                        )));
-                    }
-
-                    table.for_each(|key: String, val: Value| {
-                        self.dispatch_application_event(&key, val, Some(&current_key))
-                    })
-                }
-                None => Ok(()),
-            },
-            _ => Ok(()),
+        if let Value::Table(table) = value {
+            if let Some(_) = get_cleanup_entries_metatable(&table)? {
+                return table.for_each(|key: String, val: Value| {
+                    self.dispatch_application_event(&key, val, Some(&current_key))
+                });
+            }
         }
+
+        Ok(())
     }
 
     fn dispatch_keyboard_event(&self, lua: &Lua, event: KeyboardEvent) -> mlua::Result<()> {
@@ -107,194 +101,5 @@ impl UserData for Events {
             "register",
             |_lua, this, (event, on_match): (String, Function)| this.register(event, on_match),
         );
-    }
-}
-
-struct EventEntry {
-    event: String,
-    on_match: Function,
-}
-
-const CLEANUP_ENTRIES: &str = "__cleanup_entries";
-
-pub fn get_cleanup_entries_metatable(table: &Table) -> mlua::Result<Option<Table>> {
-    match table.metatable() {
-        Some(metatable) => metatable.get(CLEANUP_ENTRIES),
-        None => Ok(None),
-    }
-}
-
-pub fn proto_to_lua_value(lua: &Lua, field: Field) -> mlua::Result<Value> {
-    match field.field {
-        Some(FieldEntry::FNone(_)) | None => Ok(mlua::Nil),
-        Some(FieldEntry::FBool(bool)) => Ok(Value::Boolean(bool)),
-        Some(FieldEntry::FInteger(integer)) => Ok(Value::Integer(integer)),
-        Some(FieldEntry::FFloat(float)) => Ok(Value::Number(float)),
-        Some(FieldEntry::FString(string)) => {
-            let string = lua.create_string(string)?;
-            Ok(Value::String(string))
-        }
-        Some(FieldEntry::FArray(array)) => {
-            let size = array.items.len();
-            let table = lua.create_table_with_capacity(size, 0)?;
-            for value in array.items {
-                table.push(proto_to_lua_value(lua, value)?)?;
-            }
-            Ok(Value::Table(table))
-        }
-        Some(FieldEntry::FTable(map)) => {
-            let size = map.items.len();
-
-            let table = lua.create_table_with_capacity(0, size)?;
-            let cleanup_entries = lua.create_table_with_capacity(0, size)?;
-
-            for (key, value) in map.items {
-                match proto_to_lua_value(lua, value)? {
-                    Value::Nil => cleanup_entries.set(key, true)?,
-                    value => table.set(key, value)?,
-                }
-            }
-
-            let meta = lua.create_table_with_capacity(0, 1)?;
-            meta.set(CLEANUP_ENTRIES, cleanup_entries)?;
-            _ = table.set_metatable(Some(meta));
-
-            Ok(Value::Table(table))
-        }
-        Some(FieldEntry::FImageData(image)) => {
-            let hash = hash(&image.data);
-            let image_data = ImageData {
-                format: image.format().try_into().map_err(mlua::Error::external)?,
-                bytes: image.data,
-                hash: Some(hash),
-            };
-            let user_data = lua.create_any_userdata(image_data)?;
-            Ok(Value::UserData(user_data))
-        }
-    }
-}
-fn hash<T: Hash>(t: &T) -> u64 {
-    let mut s = DefaultHasher::new();
-    t.hash(&mut s);
-    s.finish()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use omni_led_api::types::None;
-    use omni_led_derive::IntoProto;
-
-    #[test]
-    fn convert_nil() {
-        let lua = Lua::new();
-        assert_eq!(
-            proto_to_lua_value(&lua, None {}.into()).unwrap(),
-            Value::Nil
-        )
-    }
-
-    #[test]
-    fn convert_bool() {
-        let lua = Lua::new();
-        assert_eq!(
-            proto_to_lua_value(&lua, true.into()).unwrap(),
-            Value::Boolean(true)
-        )
-    }
-
-    #[test]
-    fn convert_integer() {
-        let lua = Lua::new();
-        assert_eq!(
-            proto_to_lua_value(&lua, 68.into()).unwrap(),
-            Value::Integer(68)
-        )
-    }
-
-    #[test]
-    fn convert_float() {
-        let lua = Lua::new();
-        assert_eq!(
-            proto_to_lua_value(&lua, 6.8.into()).unwrap(),
-            Value::Number(6.8)
-        )
-    }
-
-    #[test]
-    fn convert_string() {
-        let lua = Lua::new();
-        let string = "Omegalul";
-        assert_eq!(
-            proto_to_lua_value(&lua, string.into()).unwrap(),
-            Value::String(lua.create_string(string).unwrap())
-        )
-    }
-
-    #[test]
-    fn convert_array() {
-        let lua = Lua::new();
-        let array = vec![1, 2, 3, 4];
-
-        let result = proto_to_lua_value(&lua, array.clone().into()).unwrap();
-        assert!(result.is_table());
-
-        let result = result.as_table().unwrap();
-        let cleanup_entries = get_cleanup_entries_metatable(result).unwrap();
-
-        assert!(cleanup_entries.is_none());
-        assert_eq!(result.len().unwrap() as usize, array.len());
-        result
-            .for_each(|lua_index: usize, value: i64| {
-                let index = lua_index - 1;
-                assert_eq!(value, array[index], "Missmatch at index {}", index);
-                Ok(())
-            })
-            .unwrap();
-    }
-
-    #[test]
-    fn convert_table() {
-        #[derive(IntoProto)]
-        struct Input {
-            a: i64,
-            b: String,
-            c: Option<bool>,
-            d: Option<bool>,
-            #[proto(strong_none)]
-            e: Option<f64>,
-            #[proto(strong_none)]
-            f: Option<f64>,
-        }
-
-        let lua = Lua::new();
-        let input = Input {
-            a: 0,
-            b: "b".to_string(),
-            c: None,
-            d: Some(true),
-            e: None,
-            f: Some(1.23),
-        };
-
-        let result = proto_to_lua_value(&lua, input.into()).unwrap();
-        assert!(result.is_table());
-
-        let result = result.as_table().unwrap();
-        let cleanup_entries = get_cleanup_entries_metatable(result).unwrap();
-
-        assert!(cleanup_entries.is_some());
-
-        let cleanup_entries = cleanup_entries.unwrap();
-
-        assert_eq!(cleanup_entries.pairs::<Value, Value>().count(), 1);
-        // We only care that the key is present. As long as it's there, the condition will hold.
-        assert_ne!(cleanup_entries.get::<Value>("e").unwrap(), Value::Nil);
-
-        assert_eq!(result.pairs::<Value, Value>().count(), 4);
-        assert_eq!(result.get::<i64>("a").unwrap(), 0);
-        assert_eq!(result.get::<String>("b").unwrap(), String::from("b"));
-        assert_eq!(result.get::<Option<bool>>("d").unwrap(), Some(true));
-        assert_eq!(result.get::<Option<f64>>("f").unwrap(), Some(1.23));
     }
 }

--- a/omni-led-lib/src/events/events.rs
+++ b/omni-led-lib/src/events/events.rs
@@ -2,6 +2,7 @@ use log::warn;
 use mlua::{ErrorContext, FromLua, Function, Lua, UserData, UserDataMethods, Value};
 use omni_led_api::types::{Field, field};
 use omni_led_derive::UniqueUserData;
+use regex::Regex;
 
 use crate::common::user_data::UniqueUserData;
 use crate::events::event_queue::Event;
@@ -26,8 +27,34 @@ impl FromLua for EventHandle {
     }
 }
 
+pub enum EventKey {
+    Regex(Regex),
+    String(String),
+}
+
+impl EventKey {
+    fn matches(&self, event: &str) -> bool {
+        match self {
+            EventKey::Regex(regex) => regex.is_match(event),
+            EventKey::String(string) => string == event,
+        }
+    }
+}
+
+impl From<String> for EventKey {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<Regex> for EventKey {
+    fn from(value: Regex) -> Self {
+        Self::Regex(value)
+    }
+}
+
 struct EventEntry {
-    event: String,
+    key: EventKey,
     on_match: Function,
     handle: EventHandle,
     persistent: bool,
@@ -50,12 +77,17 @@ impl Events {
         );
     }
 
-    pub fn register(&mut self, event: String, on_match: Function, persistent: bool) -> EventHandle {
+    pub fn register<K: Into<EventKey>>(
+        &mut self,
+        key: K,
+        on_match: Function,
+        persistent: bool,
+    ) -> EventHandle {
         self.counter += 1;
         let handle = EventHandle(self.counter);
 
         self.entries.push(EventEntry {
-            event,
+            key: key.into(),
             on_match,
             persistent,
             handle,
@@ -132,7 +164,7 @@ impl Events {
 
     fn dispatch_event(&self, event: &str, value: &Value) -> mlua::Result<()> {
         for entry in &self.entries {
-            if entry.event == event || entry.event == "*" {
+            if entry.key.matches(event) {
                 entry
                     .on_match
                     .call::<()>((event.to_string(), value.clone()))?;
@@ -149,6 +181,15 @@ impl UserData for Events {
             |_lua, this, (event, on_match): (String, Function)| {
                 // Registering from user scripts must never be persistent to avoid issues on reloads
                 Ok(this.register(event, on_match, false))
+            },
+        );
+
+        methods.add_method_mut(
+            "register_regex",
+            |_lua, this, (event, on_match): (String, Function)| {
+                // Registering from user scripts must never be persistent to avoid issues on reloads
+                let regex = Regex::new(&event).map_err(mlua::Error::external)?;
+                Ok(this.register(regex, on_match, false))
             },
         );
 

--- a/omni-led-lib/src/events/events.rs
+++ b/omni-led-lib/src/events/events.rs
@@ -2,54 +2,28 @@ use log::warn;
 use mlua::{ErrorContext, FromLua, Function, Lua, UserData, UserDataMethods, Value};
 use omni_led_api::types::{Field, field};
 use omni_led_derive::UniqueUserData;
-use regex::Regex;
 
+use crate::common::lua_traits::{FromUserdata, LuaName};
 use crate::common::user_data::UniqueUserData;
 use crate::events::event_queue::Event;
 use crate::events::proto_to_lua::{get_cleanup_entries_metatable, proto_to_lua_value};
 use crate::keyboard::keyboard::{KeyboardEvent, KeyboardEventEventType};
+use crate::script_handler::script_data_types::EventKey;
 
 #[derive(Clone, Copy, PartialEq)]
 pub struct EventHandle(usize);
 
 impl UserData for EventHandle {}
 
+impl LuaName for EventHandle {
+    const NAME: &str = "EventHandle";
+}
+
+impl FromUserdata for EventHandle {}
+
 impl FromLua for EventHandle {
-    fn from_lua(value: Value, _lua: &Lua) -> mlua::Result<Self> {
-        match value {
-            Value::UserData(user_data) => user_data.borrow::<Self>().map(|k| k.clone()),
-            other => Err(mlua::Error::FromLuaConversionError {
-                from: other.type_name(),
-                to: "EventHandle".to_string(),
-                message: Some("Expected EventHandle object".to_string()),
-            }),
-        }
-    }
-}
-
-pub enum EventKey {
-    Regex(Regex),
-    String(String),
-}
-
-impl EventKey {
-    fn matches(&self, event: &str) -> bool {
-        match self {
-            EventKey::Regex(regex) => regex.is_match(event),
-            EventKey::String(string) => string == event,
-        }
-    }
-}
-
-impl From<String> for EventKey {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
-
-impl From<Regex> for EventKey {
-    fn from(value: Regex) -> Self {
-        Self::Regex(value)
+    fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+        Self::from_userdata(lua, value)
     }
 }
 
@@ -77,12 +51,7 @@ impl Events {
         );
     }
 
-    pub fn register<K: Into<EventKey>>(
-        &mut self,
-        key: K,
-        on_match: Function,
-        persistent: bool,
-    ) -> EventHandle {
+    pub fn register(&mut self, key: EventKey, on_match: Function, persistent: bool) -> EventHandle {
         self.counter += 1;
         let handle = EventHandle(self.counter);
 
@@ -178,18 +147,9 @@ impl UserData for Events {
     fn add_methods<'lua, M: UserDataMethods<Self>>(methods: &mut M) {
         methods.add_method_mut(
             "register",
-            |_lua, this, (event, on_match): (String, Function)| {
+            |_lua, this, (key, on_match): (EventKey, Function)| {
                 // Registering from user scripts must never be persistent to avoid issues on reloads
-                Ok(this.register(event, on_match, false))
-            },
-        );
-
-        methods.add_method_mut(
-            "register_regex",
-            |_lua, this, (event, on_match): (String, Function)| {
-                // Registering from user scripts must never be persistent to avoid issues on reloads
-                let regex = Regex::new(&event).map_err(mlua::Error::external)?;
-                Ok(this.register(regex, on_match, false))
+                Ok(this.register(key, on_match, false))
             },
         );
 

--- a/omni-led-lib/src/events/events.rs
+++ b/omni-led-lib/src/events/events.rs
@@ -1,4 +1,5 @@
-use mlua::{ErrorContext, Function, Lua, UserData, UserDataMethods, Value};
+use log::warn;
+use mlua::{ErrorContext, FromLua, Function, Lua, UserData, UserDataMethods, Value};
 use omni_led_api::types::{Field, field};
 use omni_led_derive::UniqueUserData;
 
@@ -7,14 +8,35 @@ use crate::events::event_queue::Event;
 use crate::events::proto_to_lua::{get_cleanup_entries_metatable, proto_to_lua_value};
 use crate::keyboard::keyboard::{KeyboardEvent, KeyboardEventEventType};
 
+#[derive(Clone, Copy, PartialEq)]
+pub struct EventHandle(usize);
+
+impl UserData for EventHandle {}
+
+impl FromLua for EventHandle {
+    fn from_lua(value: Value, _lua: &Lua) -> mlua::Result<Self> {
+        match value {
+            Value::UserData(user_data) => user_data.borrow::<Self>().map(|k| k.clone()),
+            other => Err(mlua::Error::FromLuaConversionError {
+                from: other.type_name(),
+                to: "EventHandle".to_string(),
+                message: Some("Expected EventHandle object".to_string()),
+            }),
+        }
+    }
+}
+
 struct EventEntry {
     event: String,
     on_match: Function,
+    handle: EventHandle,
+    persistent: bool,
 }
 
 #[derive(UniqueUserData)]
 pub struct Events {
     entries: Vec<EventEntry>,
+    counter: usize,
 }
 
 impl Events {
@@ -23,14 +45,39 @@ impl Events {
             lua,
             Self {
                 entries: Vec::new(),
+                counter: 0,
             },
         );
     }
 
-    pub fn register(&mut self, event: String, on_match: Function) -> mlua::Result<()> {
-        self.entries.push(EventEntry { event, on_match });
+    pub fn register(&mut self, event: String, on_match: Function, persistent: bool) -> EventHandle {
+        self.counter += 1;
+        let handle = EventHandle(self.counter);
 
+        self.entries.push(EventEntry {
+            event,
+            on_match,
+            persistent,
+            handle,
+        });
+
+        handle
+    }
+
+    pub fn unregister(&mut self, handle: EventHandle) -> mlua::Result<()> {
+        match self.entries.iter().position(|entry| entry.handle == handle) {
+            Some(index) => {
+                self.entries.remove(index);
+            }
+            None => {
+                warn!("Failed to unregister event. Key {} not found", handle.0);
+            }
+        };
         Ok(())
+    }
+
+    pub fn clear_non_persistent(&mut self) {
+        self.entries.retain(|entry| entry.persistent);
     }
 
     pub fn dispatch(&self, lua: &Lua, event: Event) -> mlua::Result<()> {
@@ -99,7 +146,14 @@ impl UserData for Events {
     fn add_methods<'lua, M: UserDataMethods<Self>>(methods: &mut M) {
         methods.add_method_mut(
             "register",
-            |_lua, this, (event, on_match): (String, Function)| this.register(event, on_match),
+            |_lua, this, (event, on_match): (String, Function)| {
+                // Registering from user scripts must never be persistent to avoid issues on reloads
+                Ok(this.register(event, on_match, false))
+            },
         );
+
+        methods.add_method_mut("unregister", |_lua, this, key: EventHandle| {
+            this.unregister(key)
+        });
     }
 }

--- a/omni-led-lib/src/events/mod.rs
+++ b/omni-led-lib/src/events/mod.rs
@@ -1,4 +1,5 @@
 pub mod event_loop;
 pub mod event_queue;
 pub mod events;
+pub mod proto_to_lua;
 pub mod shortcuts;

--- a/omni-led-lib/src/events/proto_to_lua.rs
+++ b/omni-led-lib/src/events/proto_to_lua.rs
@@ -1,0 +1,191 @@
+use mlua::{Lua, Table, Value};
+use omni_led_api::types::Field;
+use omni_led_api::types::field::Field as FieldEntry;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use crate::script_handler::script_data_types::ImageData;
+
+const CLEANUP_ENTRIES: &str = "__cleanup_entries";
+
+pub fn get_cleanup_entries_metatable(table: &Table) -> mlua::Result<Option<Table>> {
+    match table.metatable() {
+        Some(metatable) => metatable.get(CLEANUP_ENTRIES),
+        None => Ok(None),
+    }
+}
+
+pub fn proto_to_lua_value(lua: &Lua, field: Field) -> mlua::Result<Value> {
+    match field.field {
+        Some(FieldEntry::FNone(_)) | None => Ok(mlua::Nil),
+        Some(FieldEntry::FBool(bool)) => Ok(Value::Boolean(bool)),
+        Some(FieldEntry::FInteger(integer)) => Ok(Value::Integer(integer)),
+        Some(FieldEntry::FFloat(float)) => Ok(Value::Number(float)),
+        Some(FieldEntry::FString(string)) => {
+            let string = lua.create_string(string)?;
+            Ok(Value::String(string))
+        }
+        Some(FieldEntry::FArray(array)) => {
+            let size = array.items.len();
+            let table = lua.create_table_with_capacity(size, 0)?;
+            for value in array.items {
+                table.push(proto_to_lua_value(lua, value)?)?;
+            }
+            Ok(Value::Table(table))
+        }
+        Some(FieldEntry::FTable(map)) => {
+            let size = map.items.len();
+
+            let table = lua.create_table_with_capacity(0, size)?;
+            let cleanup_entries = lua.create_table_with_capacity(0, size)?;
+
+            for (key, value) in map.items {
+                match proto_to_lua_value(lua, value)? {
+                    Value::Nil => cleanup_entries.set(key, true)?,
+                    value => table.set(key, value)?,
+                }
+            }
+
+            let meta = lua.create_table_with_capacity(0, 1)?;
+            meta.set(CLEANUP_ENTRIES, cleanup_entries)?;
+            _ = table.set_metatable(Some(meta));
+
+            Ok(Value::Table(table))
+        }
+        Some(FieldEntry::FImageData(image)) => {
+            let hash = hash(&image.data);
+            let image_data = ImageData {
+                format: image.format().try_into().map_err(mlua::Error::external)?,
+                bytes: image.data,
+                hash: Some(hash),
+            };
+            let user_data = lua.create_any_userdata(image_data)?;
+            Ok(Value::UserData(user_data))
+        }
+    }
+}
+
+fn hash<T: Hash>(t: &T) -> u64 {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omni_led_api::types::None;
+    use omni_led_derive::IntoProto;
+
+    #[test]
+    fn convert_nil() {
+        let lua = Lua::new();
+        assert_eq!(
+            proto_to_lua_value(&lua, None {}.into()).unwrap(),
+            Value::Nil
+        )
+    }
+
+    #[test]
+    fn convert_bool() {
+        let lua = Lua::new();
+        assert_eq!(
+            proto_to_lua_value(&lua, true.into()).unwrap(),
+            Value::Boolean(true)
+        )
+    }
+
+    #[test]
+    fn convert_integer() {
+        let lua = Lua::new();
+        assert_eq!(
+            proto_to_lua_value(&lua, 68.into()).unwrap(),
+            Value::Integer(68)
+        )
+    }
+
+    #[test]
+    fn convert_float() {
+        let lua = Lua::new();
+        assert_eq!(
+            proto_to_lua_value(&lua, 6.8.into()).unwrap(),
+            Value::Number(6.8)
+        )
+    }
+
+    #[test]
+    fn convert_string() {
+        let lua = Lua::new();
+        let string = "Omegalul";
+        assert_eq!(
+            proto_to_lua_value(&lua, string.into()).unwrap(),
+            Value::String(lua.create_string(string).unwrap())
+        )
+    }
+
+    #[test]
+    fn convert_array() {
+        let lua = Lua::new();
+        let array = vec![1, 2, 3, 4];
+
+        let result = proto_to_lua_value(&lua, array.clone().into()).unwrap();
+        assert!(result.is_table());
+
+        let result = result.as_table().unwrap();
+        let cleanup_entries = get_cleanup_entries_metatable(result).unwrap();
+
+        assert!(cleanup_entries.is_none());
+        assert_eq!(result.len().unwrap() as usize, array.len());
+        result
+            .for_each(|lua_index: usize, value: i64| {
+                let index = lua_index - 1;
+                assert_eq!(value, array[index], "Missmatch at index {}", index);
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn convert_table() {
+        #[derive(IntoProto)]
+        struct Input {
+            a: i64,
+            b: String,
+            c: Option<bool>,
+            d: Option<bool>,
+            #[proto(strong_none)]
+            e: Option<f64>,
+            #[proto(strong_none)]
+            f: Option<f64>,
+        }
+
+        let lua = Lua::new();
+        let input = Input {
+            a: 0,
+            b: "b".to_string(),
+            c: None,
+            d: Some(true),
+            e: None,
+            f: Some(1.23),
+        };
+
+        let result = proto_to_lua_value(&lua, input.into()).unwrap();
+        assert!(result.is_table());
+
+        let result = result.as_table().unwrap();
+        let cleanup_entries = get_cleanup_entries_metatable(result).unwrap();
+
+        assert!(cleanup_entries.is_some());
+
+        let cleanup_entries = cleanup_entries.unwrap();
+
+        assert_eq!(cleanup_entries.pairs::<Value, Value>().count(), 1);
+        // We only care that the key is present. As long as it's there, the condition will hold.
+        assert_ne!(cleanup_entries.get::<Value>("e").unwrap(), Value::Nil);
+
+        assert_eq!(result.pairs::<Value, Value>().count(), 4);
+        assert_eq!(result.get::<i64>("a").unwrap(), 0);
+        assert_eq!(result.get::<String>("b").unwrap(), String::from("b"));
+        assert_eq!(result.get::<Option<bool>>("d").unwrap(), Some(true));
+        assert_eq!(result.get::<Option<f64>>("f").unwrap(), Some(1.23));
+    }
+}

--- a/omni-led-lib/src/events/shortcuts.rs
+++ b/omni-led-lib/src/events/shortcuts.rs
@@ -38,8 +38,7 @@ impl Shortcuts {
         let mut events = UserDataRef::<Events>::load(lua);
         events
             .get_mut()
-            .register("OMNILED.Update".to_string(), function)
-            .unwrap();
+            .register("OMNILED.Update".to_string(), function, true);
 
         Self::set_unique(
             lua,
@@ -152,7 +151,7 @@ impl Shortcuts {
 
         let mut events = UserDataRef::<Events>::load(lua);
         for key in keys {
-            events.get_mut().register(key, function.clone())?;
+            events.get_mut().register(key, function.clone(), false);
         }
 
         Ok(())

--- a/omni-led-lib/src/events/shortcuts.rs
+++ b/omni-led-lib/src/events/shortcuts.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 
 use crate::common::user_data::{UniqueUserData, UserDataRef};
 use crate::events::events::Events;
+use crate::script_handler::script_data_types::EventKey;
 use crate::settings::settings::Settings;
 
 #[derive(UniqueUserData)]
@@ -36,9 +37,11 @@ impl Shortcuts {
             .unwrap();
 
         let mut events = UserDataRef::<Events>::load(lua);
-        events
-            .get_mut()
-            .register("OMNILED.Update".to_string(), function, true);
+        events.get_mut().register(
+            EventKey::String("OMNILED.Update".to_string()),
+            function,
+            true,
+        );
 
         Self::set_unique(
             lua,
@@ -151,7 +154,9 @@ impl Shortcuts {
 
         let mut events = UserDataRef::<Events>::load(lua);
         for key in keys {
-            events.get_mut().register(key, function.clone(), false);
+            events
+                .get_mut()
+                .register(EventKey::String(key), function.clone(), false);
         }
 
         Ok(())

--- a/omni-led-lib/src/renderer/font_selector.rs
+++ b/omni-led-lib/src/renderer/font_selector.rs
@@ -137,7 +137,7 @@ impl Into<font_kit::properties::Stretch> for Stretch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::lua_enum::set_lua_enums;
+    use crate::common::lua_register::set_lua_enums;
     use mlua::{Lua, chunk};
 
     macro_rules! eval {

--- a/omni-led-lib/src/script_handler/script_data_types.rs
+++ b/omni-led-lib/src/script_handler/script_data_types.rs
@@ -1,6 +1,8 @@
-use mlua::{ErrorContext, FromLua, Lua, UserData, UserDataFields};
+use mlua::{ErrorContext, FromLua, Lua, UserData, UserDataFields, UserDataMethods, Value};
 use omni_led_derive::{FromLuaValue, LuaEnum};
 use std::hash::Hash;
+
+use crate::common::lua_traits::{FromUserdata, LuaConstructor, LuaName};
 
 #[derive(Debug, Clone, Copy, FromLuaValue)]
 pub struct Point {
@@ -224,3 +226,72 @@ pub enum MemoryLayout {
 }
 
 impl UserData for MemoryLayout {}
+
+#[derive(Clone)]
+pub struct Regex {
+    re: regex::Regex,
+}
+
+impl Regex {
+    pub fn new(re: &str) -> mlua::Result<Self> {
+        let re = regex::Regex::new(re).map_err(mlua::Error::external)?;
+        Ok(Self { re })
+    }
+
+    pub fn matches(&self, string: &str) -> bool {
+        self.re.is_match(string)
+    }
+}
+
+impl LuaName for Regex {
+    const NAME: &str = "Regex";
+}
+
+impl LuaConstructor for Regex {
+    type Args = String;
+
+    fn constructor(_lua: &Lua, re: Self::Args) -> mlua::Result<Self> {
+        Regex::new(&re)
+    }
+}
+
+impl UserData for Regex {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("matches", |_, this, string: String| {
+            Ok(this.matches(&string))
+        });
+    }
+}
+
+impl FromUserdata for Regex {}
+
+impl FromLua for Regex {
+    fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+        Self::from_userdata(lua, value)
+    }
+}
+
+#[derive(Clone, LuaEnum)]
+pub enum EventKey {
+    #[mlua(construct_from)]
+    Regex(Regex),
+    #[mlua(construct_from)]
+    String(String),
+}
+
+impl EventKey {
+    pub fn matches(&self, event: &str) -> bool {
+        match self {
+            EventKey::Regex(regex) => regex.matches(event),
+            EventKey::String(string) => string == event,
+        }
+    }
+}
+
+impl UserData for EventKey {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("matches", |_, this, string: String| {
+            Ok(this.matches(&string))
+        });
+    }
+}

--- a/omni-led-lib/src/script_handler/script_data_types.rs
+++ b/omni-led-lib/src/script_handler/script_data_types.rs
@@ -192,6 +192,7 @@ impl UserData for Text {}
 
 #[derive(Copy, Clone, Debug, LuaEnum)]
 pub enum FontSize {
+    #[mlua(implicit_construct)]
     Value(usize),
     Auto,
     AutoUpper,
@@ -273,9 +274,9 @@ impl FromLua for Regex {
 
 #[derive(Clone, LuaEnum)]
 pub enum EventKey {
-    #[mlua(construct_from)]
+    #[mlua(implicit_construct)]
     Regex(Regex),
-    #[mlua(construct_from)]
+    #[mlua(implicit_construct)]
     String(String),
 }
 

--- a/omni-led-lib/src/script_handler/script_handler.rs
+++ b/omni-led-lib/src/script_handler/script_handler.rs
@@ -70,8 +70,7 @@ impl ScriptHandler {
         let mut events = UserDataRef::<Events>::load(lua);
         events
             .get_mut()
-            .register("*".to_string(), event_handler)
-            .unwrap();
+            .register("*".to_string(), event_handler, true);
 
         load_config(lua, ConfigType::Scripts, &config, environment).unwrap();
     }

--- a/omni-led-lib/src/script_handler/script_handler.rs
+++ b/omni-led-lib/src/script_handler/script_handler.rs
@@ -2,7 +2,6 @@ use log::warn;
 use mlua::{ErrorContext, FromLua, Function, Lua, Table, UserData, UserDataMethods, Value, chunk};
 use omni_led_api::plugin::Plugin;
 use omni_led_derive::{FromLuaValue, UniqueUserData};
-use regex::Regex;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -19,7 +18,7 @@ use crate::events::shortcuts::Shortcuts;
 use crate::renderer::animation::State;
 use crate::renderer::animation_group::AnimationGroup;
 use crate::renderer::renderer::Renderer;
-use crate::script_handler::script_data_types::Widget;
+use crate::script_handler::script_data_types::{EventKey, Regex, Widget};
 
 #[derive(UniqueUserData)]
 pub struct ScriptHandler {
@@ -70,7 +69,9 @@ impl ScriptHandler {
 
         let mut events = UserDataRef::<Events>::load(lua);
         let regex = Regex::new(".*").unwrap();
-        events.get_mut().register(regex, event_handler, true);
+        events
+            .get_mut()
+            .register(EventKey::Regex(regex), event_handler, true);
         std::mem::drop(events);
 
         load_config(lua, ConfigType::Scripts, &config, environment).unwrap();
@@ -116,8 +117,11 @@ impl ScriptHandler {
     fn mark_for_update(&mut self, key: &String) {
         for device in &mut self.devices {
             for (index, layout) in device.layouts.iter().enumerate() {
-                if layout.run_on.contains(key) {
-                    device.layout_update_flags[index] = true;
+                for event_key in &layout.run_on {
+                    if event_key.matches(key) {
+                        device.layout_update_flags[index] = true;
+                        break;
+                    }
                 }
             }
         }
@@ -302,7 +306,7 @@ impl UserData for ScriptHandler {
 struct Layout {
     layout: Function,
     predicate: Option<Function>,
-    run_on: Vec<String>,
+    run_on: Vec<EventKey>,
 }
 
 #[derive(FromLuaValue, Clone)]

--- a/omni-led-lib/src/script_handler/script_handler.rs
+++ b/omni-led-lib/src/script_handler/script_handler.rs
@@ -12,7 +12,8 @@ use crate::constants::config::{ConfigType, load_config};
 use crate::create_table_with_defaults;
 use crate::devices::device::Device;
 use crate::devices::devices::{DeviceStatus, Devices};
-use crate::events::events::{Events, get_cleanup_entries_metatable};
+use crate::events::events::Events;
+use crate::events::proto_to_lua::get_cleanup_entries_metatable;
 use crate::events::shortcuts::Shortcuts;
 use crate::renderer::animation::State;
 use crate::renderer::animation_group::AnimationGroup;
@@ -502,8 +503,7 @@ impl UserData for ScreenBuilderImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::create_table;
-    use crate::events::events::proto_to_lua_value;
+    use crate::{create_table, events::proto_to_lua::proto_to_lua_value};
     use omni_led_derive::IntoProto;
 
     fn assert_tables_equal(lua: &Lua, left: &Table, right: &Table, line: u32) {

--- a/omni-led-lib/src/script_handler/script_handler.rs
+++ b/omni-led-lib/src/script_handler/script_handler.rs
@@ -2,6 +2,7 @@ use log::warn;
 use mlua::{ErrorContext, FromLua, Function, Lua, Table, UserData, UserDataMethods, Value, chunk};
 use omni_led_api::plugin::Plugin;
 use omni_led_derive::{FromLuaValue, UniqueUserData};
+use regex::Regex;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -68,9 +69,9 @@ impl ScriptHandler {
             .unwrap();
 
         let mut events = UserDataRef::<Events>::load(lua);
-        events
-            .get_mut()
-            .register("*".to_string(), event_handler, true);
+        let regex = Regex::new(".*").unwrap();
+        events.get_mut().register(regex, event_handler, true);
+        std::mem::drop(events);
 
         load_config(lua, ConfigType::Scripts, &config, environment).unwrap();
     }


### PR DESCRIPTION
New features:
- Some enums can now be implicitly constructed from their variant types, e.g. `font_size = FontSize.Value(50)` *can* (but doesn't have to)  be replaced with `font_size = 50`.
- Events can now be filtered with regex.
- Events can now be unregistered from.

Breaking changes:
- Deprecated `RawUsbDeviceSettings.memory_representation` field is now removed, leaving `RawUsbDeviceSettings.memory_layout`.