### PR TITLE
Better log filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,7 +3158,6 @@ dependencies = [
  "log",
  "prost",
  "tokio",
- "tokio-stream",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",

--- a/omni-led-api/Cargo.toml
+++ b/omni-led-api/Cargo.toml
@@ -12,7 +12,6 @@ image = "0.25"
 log = { version = "0.4", features = ["std"] }
 prost = "0.14"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1"
 tonic = "0.14"
 tonic-prost = "0.14"
 

--- a/omni-led-api/proto/plugin.proto
+++ b/omni-led-api/proto/plugin.proto
@@ -4,7 +4,7 @@ package plugin;
 
 service Plugin {
   rpc Event(EventData) returns (EventResponse);
-  rpc Log(stream LogData) returns (LogResponse);
+  rpc Log(LogData) returns (LogResponse);
 }
 
 message EventData {
@@ -75,18 +75,6 @@ enum LogLevel {
   LOG_LEVEL_TRACE = 5;
 }
 
-message LogResponse {
-  LogLevelFilter log_level_filter = 1;
-}
-
-enum LogLevelFilter {
-  LOG_LEVEL_FILTER_UNKNOWN = 0;
-  LOG_LEVEL_FILTER_OFF = 1;
-  LOG_LEVEL_FILTER_ERROR = 2;
-  LOG_LEVEL_FILTER_WARN = 3;
-  LOG_LEVEL_FILTER_INFO = 4;
-  LOG_LEVEL_FILTER_DEBUG = 5;
-  LOG_LEVEL_FILTER_TRACE = 6;
-}
+message LogResponse {}
 
 message None {}

--- a/omni-led-api/src/logging.rs
+++ b/omni-led-api/src/logging.rs
@@ -1,13 +1,12 @@
-use log::{LevelFilter, Log, Metadata, Record, error};
+use log::{Log, Metadata, Record, error};
 use tokio::runtime::Handle;
-use tokio::sync::mpsc::Sender;
 
-use crate::types::{LogData, LogLevel};
+use crate::plugin::Plugin;
 
-pub fn init(runtime_handle: Handle, log_sink: Sender<LogData>, log_level_filter: LevelFilter) {
-    let logger = Logger::new(runtime_handle, log_sink, log_level_filter);
+pub fn init(runtime_handle: Handle, plugin: Plugin, crate_name: &'static str) {
+    let logger = Logger::new(runtime_handle, plugin, crate_name);
     log::set_boxed_logger(Box::new(logger))
-        .map(|()| log::set_max_level(log_level_filter))
+        .map(|()| log::set_max_level(log::LevelFilter::Trace))
         .unwrap();
 
     let default_hook = std::panic::take_hook();
@@ -19,27 +18,24 @@ pub fn init(runtime_handle: Handle, log_sink: Sender<LogData>, log_level_filter:
 
 struct Logger {
     runtime_handle: Handle,
-    log_sink: Sender<LogData>,
-    log_level_filter: LevelFilter,
+    plugin: Plugin,
+    crate_name: &'static str,
 }
 
 impl Logger {
-    pub fn new(
-        runtime_handle: Handle,
-        log_sink: Sender<LogData>,
-        log_level_filter: LevelFilter,
-    ) -> Self {
+    pub fn new(runtime_handle: Handle, plugin: Plugin, crate_name: &'static str) -> Self {
         Self {
             runtime_handle,
-            log_sink,
-            log_level_filter,
+            plugin,
+            crate_name,
         }
     }
 }
 
 impl Log for Logger {
     fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= self.log_level_filter
+        let target = metadata.target();
+        target.starts_with(self.crate_name) || target.starts_with("omni_led")
     }
 
     fn log(&self, record: &Record) {
@@ -47,16 +43,13 @@ impl Log for Logger {
             return;
         }
 
-        let log_level: LogLevel = record.level().into();
-        let data = LogData {
-            log_level: log_level as i32,
-            location: record.target().to_string(),
-            message: format!("{}", record.args()),
-        };
-
-        let log_sink = self.log_sink.clone();
-        self.runtime_handle
-            .spawn(async move { log_sink.send(data).await.unwrap() });
+        let log_level = record.level();
+        let target = record.target().to_string();
+        let message = format!("{}", record.args());
+        let plugin = self.plugin.clone();
+        self.runtime_handle.spawn(async move {
+            _ = plugin.log(log_level.into(), target, message).await;
+        });
     }
 
     fn flush(&self) {}

--- a/omni-led-api/src/plugin.rs
+++ b/omni-led-api/src/plugin.rs
@@ -1,53 +1,82 @@
-use tokio::runtime::Handle;
-use tokio::sync::mpsc::channel;
-use tokio_stream::wrappers::ReceiverStream;
+use std::sync::Arc;
+use tokio::{runtime::Handle, sync::Mutex};
 
-use crate::logging;
-use crate::types::{EventData, Table, plugin_client};
+use crate::{
+    logging,
+    types::{EventData, LogData, LogLevel, Table, plugin_client::PluginClient},
+};
 
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct Plugin {
+    inner: Arc<Mutex<PluginInner>>,
+}
+
+struct PluginInner {
     name: String,
-    client: plugin_client::PluginClient<tonic::transport::Channel>,
+    client: PluginClient<tonic::transport::Channel>,
 }
 
 impl Plugin {
-    pub async fn new(name: &str, url: &str) -> Result<Self, tonic::transport::Error> {
-        let mut client = plugin_client::PluginClient::connect(format!("http://{url}")).await?;
+    pub async fn new(
+        name: &str,
+        crate_name: &'static str,
+        url: &str,
+    ) -> Result<Self, tonic::transport::Error> {
+        let client = PluginClient::connect(format!("http://{url}")).await?;
 
-        let (tx, rx) = channel(128);
-        let stream = ReceiverStream::new(rx);
-
-        let log_level: log::LevelFilter = match client.log(stream).await {
-            Ok(response) => response.into_inner().log_level_filter().into(),
-            Err(_) => todo!(),
+        let plugin = Self {
+            inner: Arc::new(Mutex::new(PluginInner {
+                name: name.to_string(),
+                client: client,
+            })),
         };
-        logging::init(Handle::current(), tx, log_level);
 
-        Ok(Self {
-            name: name.to_string(),
-            client,
-        })
+        logging::init(Handle::current(), plugin.clone(), crate_name);
+
+        Ok(plugin)
     }
 
-    pub async fn update_with_name(
-        &mut self,
-        name: &str,
-        fields: Table,
+    pub async fn log(
+        &self,
+        log_level: LogLevel,
+        location: String,
+        message: String,
     ) -> Result<(), tonic::Status> {
-        let data = EventData {
-            name: name.to_string(),
-            fields: Some(fields),
-        };
-
-        self.client.event(data).await?;
+        self.inner
+            .lock()
+            .await
+            .client
+            .log(LogData {
+                log_level: log_level as i32,
+                location: location,
+                message: message,
+            })
+            .await?;
         Ok(())
     }
 
-    pub async fn update(&mut self, fields: Table) -> Result<(), tonic::Status> {
-        let name = self.name.clone();
+    pub async fn update_with_name(&self, name: &str, fields: Table) -> Result<(), tonic::Status> {
+        let mut inner = self.inner.lock().await;
+        Self::update_impl(&mut inner.client, name.to_string(), fields).await
+    }
 
-        self.update_with_name(&name, fields).await?;
+    pub async fn update(&self, fields: Table) -> Result<(), tonic::Status> {
+        let mut inner = self.inner.lock().await;
+        let name = inner.name.clone();
+        Self::update_impl(&mut inner.client, name, fields).await
+    }
+
+    async fn update_impl(
+        client: &mut PluginClient<tonic::transport::Channel>,
+        name: String,
+        fields: Table,
+    ) -> Result<(), tonic::Status> {
+        client
+            .event(EventData {
+                name,
+                fields: Some(fields),
+            })
+            .await?;
         Ok(())
     }
 

--- a/omni-led-api/src/plugin.rs
+++ b/omni-led-api/src/plugin.rs
@@ -101,3 +101,23 @@ impl Plugin {
         true
     }
 }
+
+#[macro_export]
+macro_rules! new_plugin {
+    ($address:expr) => {{
+        let crate_name = env!("CARGO_PKG_NAME");
+        let plugin_name: String = crate_name
+            .chars()
+            .map(|c| {
+                if c == '-' {
+                    '_'
+                } else {
+                    c.to_ascii_uppercase()
+                }
+            })
+            .collect();
+        omni_led_api::plugin::Plugin::new(&plugin_name, crate_name, $address)
+            .await
+            .unwrap()
+    }};
+}

--- a/omni-led-api/src/types.rs
+++ b/omni-led-api/src/types.rs
@@ -29,33 +29,6 @@ impl Into<log::Level> for LogLevel {
     }
 }
 
-impl From<log::LevelFilter> for LogLevelFilter {
-    fn from(value: log::LevelFilter) -> Self {
-        match value {
-            log::LevelFilter::Off => LogLevelFilter::Off,
-            log::LevelFilter::Error => LogLevelFilter::Error,
-            log::LevelFilter::Warn => LogLevelFilter::Warn,
-            log::LevelFilter::Info => LogLevelFilter::Info,
-            log::LevelFilter::Debug => LogLevelFilter::Debug,
-            log::LevelFilter::Trace => LogLevelFilter::Trace,
-        }
-    }
-}
-
-impl Into<log::LevelFilter> for LogLevelFilter {
-    fn into(self) -> log::LevelFilter {
-        match self {
-            LogLevelFilter::Unknown => todo!(),
-            LogLevelFilter::Off => log::LevelFilter::Off,
-            LogLevelFilter::Error => log::LevelFilter::Error,
-            LogLevelFilter::Warn => log::LevelFilter::Warn,
-            LogLevelFilter::Info => log::LevelFilter::Info,
-            LogLevelFilter::Debug => log::LevelFilter::Debug,
-            LogLevelFilter::Trace => log::LevelFilter::Trace,
-        }
-    }
-}
-
 macro_rules! cast_and_into_field {
     ($from:ty, $to:ty, $variant:expr) => {
         impl Into<Field> for $from {

--- a/omni-led-applications/audio/src/main.rs
+++ b/omni-led-applications/audio/src/main.rs
@@ -1,7 +1,7 @@
 use audio::Audio;
 use clap::Parser;
 use log::debug;
-use omni_led_api::plugin::Plugin;
+use omni_led_api::new_plugin;
 use omni_led_api::types::Table;
 use omni_led_derive::IntoProto;
 use tokio::runtime::Handle;
@@ -10,15 +10,10 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 mod audio;
 
-const NAME: &str = "AUDIO";
-const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
-
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
-    let plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
-        .await
-        .unwrap();
+    let plugin = new_plugin!(&options.address);
 
     let (tx, mut rx): (
         Sender<(DeviceData, DeviceType)>,

--- a/omni-led-applications/audio/src/main.rs
+++ b/omni-led-applications/audio/src/main.rs
@@ -11,11 +11,14 @@ use tokio::sync::mpsc::{Receiver, Sender};
 mod audio;
 
 const NAME: &str = "AUDIO";
+const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
 
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
-    let mut plugin = Plugin::new(NAME, &options.address).await.unwrap();
+    let plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
+        .await
+        .unwrap();
 
     let (tx, mut rx): (
         Sender<(DeviceData, DeviceType)>,

--- a/omni-led-applications/clock/src/main.rs
+++ b/omni-led-applications/clock/src/main.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 use clap::Parser;
-use omni_led_api::plugin::Plugin;
+use omni_led_api::new_plugin;
 use omni_led_derive::IntoProto;
 use tokio::time::{Duration, Instant};
 
@@ -53,15 +53,10 @@ struct Time {
     year: i32,
 }
 
-const NAME: &str = "CLOCK";
-const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
-
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
-    let plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
-        .await
-        .unwrap();
+    let plugin = new_plugin!(&options.address);
 
     // Send initial data that will not be updated
     plugin.update(Names::new().into()).await.unwrap();

--- a/omni-led-applications/clock/src/main.rs
+++ b/omni-led-applications/clock/src/main.rs
@@ -54,11 +54,14 @@ struct Time {
 }
 
 const NAME: &str = "CLOCK";
+const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
 
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
-    let mut plugin = Plugin::new(NAME, &options.address).await.unwrap();
+    let plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
+        .await
+        .unwrap();
 
     // Send initial data that will not be updated
     plugin.update(Names::new().into()).await.unwrap();

--- a/omni-led-applications/images/src/main.rs
+++ b/omni-led-applications/images/src/main.rs
@@ -1,11 +1,8 @@
 use clap::{ArgAction, Parser};
 use image::guess_format;
 use log::{debug, error};
-use omni_led_api::plugin::Plugin;
+use omni_led_api::new_plugin;
 use omni_led_api::types::{ImageData, ImageFormat, Table};
-
-const NAME: &str = "IMAGES";
-const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
 
 #[tokio::main]
 async fn main() {
@@ -13,9 +10,7 @@ async fn main() {
 
     // TODO verify that all image names are unique
 
-    let plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
-        .await
-        .unwrap();
+    let plugin = new_plugin!(&options.address);
 
     let images = load_images(options.images);
     plugin.update(images).await.unwrap();

--- a/omni-led-applications/images/src/main.rs
+++ b/omni-led-applications/images/src/main.rs
@@ -5,6 +5,7 @@ use omni_led_api::plugin::Plugin;
 use omni_led_api::types::{ImageData, ImageFormat, Table};
 
 const NAME: &str = "IMAGES";
+const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
 
 #[tokio::main]
 async fn main() {
@@ -12,7 +13,9 @@ async fn main() {
 
     // TODO verify that all image names are unique
 
-    let mut plugin = Plugin::new(NAME, &options.address).await.unwrap();
+    let plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
+        .await
+        .unwrap();
 
     let images = load_images(options.images);
     plugin.update(images).await.unwrap();

--- a/omni-led-applications/media/src/main.rs
+++ b/omni-led-applications/media/src/main.rs
@@ -13,11 +13,14 @@ use crate::media::session_data::SessionData;
 mod media;
 
 const NAME: &str = "MEDIA";
+const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
 
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
-    let mut plugin = Plugin::new(NAME, &options.address).await.unwrap();
+    let plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
+        .await
+        .unwrap();
 
     let (tx, mut rx): (Sender<Data>, Receiver<Data>) = mpsc::channel(256);
 

--- a/omni-led-applications/media/src/main.rs
+++ b/omni-led-applications/media/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use log::info;
+use omni_led_api::new_plugin;
 use omni_led_api::plugin::Plugin;
 use omni_led_api::types::Table;
 use std::collections::HashMap;
@@ -12,15 +13,10 @@ use crate::media::session_data::SessionData;
 
 mod media;
 
-const NAME: &str = "MEDIA";
-const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
-
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
-    let plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
-        .await
-        .unwrap();
+    let plugin = new_plugin!(&options.address);
 
     let (tx, mut rx): (Sender<Data>, Receiver<Data>) = mpsc::channel(256);
 

--- a/omni-led-applications/weather/src/main.rs
+++ b/omni-led-applications/weather/src/main.rs
@@ -1,26 +1,21 @@
 use clap::Parser;
 use log::debug;
-use omni_led_api::plugin::Plugin;
 use omni_led_api::types::Table;
+use omni_led_api::{new_plugin, plugin::Plugin};
 use omni_led_derive::IntoProto;
 use std::{collections::HashMap, time};
 use ureq::Agent;
 
 mod weather_api;
 
-const NAME: &str = "WEATHER";
-const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
-
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
-    let mut plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
-        .await
-        .unwrap();
+    let plugin = new_plugin!(&options.address);
 
     debug!("{:?}", options);
 
-    load_and_send_images(&mut plugin).await;
+    load_and_send_images(&plugin).await;
 
     let (coordinates, name) = match &options.selector {
         Selector::In(name) => (get_coordinates_from_name(name), &name.city),
@@ -39,7 +34,7 @@ async fn main() {
     }
 }
 
-async fn load_and_send_images(plugin: &mut Plugin) {
+async fn load_and_send_images(plugin: &Plugin) {
     let images = weather_api::load_images();
 
     let mut table = Table::default();

--- a/omni-led-applications/weather/src/main.rs
+++ b/omni-led-applications/weather/src/main.rs
@@ -9,11 +9,14 @@ use ureq::Agent;
 mod weather_api;
 
 const NAME: &str = "WEATHER";
+const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
 
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
-    let mut plugin = Plugin::new(NAME, &options.address).await.unwrap();
+    let mut plugin = Plugin::new(NAME, CRATE_NAME, &options.address)
+        .await
+        .unwrap();
 
     debug!("{:?}", options);
 

--- a/omni-led-lib/src/server/server.rs
+++ b/omni-led-lib/src/server/server.rs
@@ -8,9 +8,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
-use tokio_stream::StreamExt;
 use tonic::transport::Server;
-use tonic::{Code, Request, Response, Status, Streaming};
+use tonic::{Code, Request, Response, Status};
 
 use crate::common::user_data::UserDataRef;
 use crate::constants::constants::Constants;
@@ -20,7 +19,6 @@ use crate::settings::settings::Settings;
 
 pub struct PluginServer {
     event_queue: Arc<Mutex<EventQueue>>,
-    log_level_filter: log::LevelFilter,
 }
 
 impl PluginServer {
@@ -38,17 +36,13 @@ impl PluginServer {
         let address = listener.local_addr().unwrap();
         let bound_port = address.port();
 
-        let log_level_filter = settings.get().log_level.into();
-
         let (tx, rx) = oneshot::channel();
         rt.spawn(
             Server::builder()
                 .add_service(
-                    omni_led_api::types::plugin_server::PluginServer::new(Self::new(
-                        log_level_filter,
-                    ))
-                    .max_decoding_message_size(64 * 1024 * 1024)
-                    .max_encoding_message_size(64 * 1024 * 1024),
+                    omni_led_api::types::plugin_server::PluginServer::new(Self::new())
+                        .max_decoding_message_size(64 * 1024 * 1024)
+                        .max_encoding_message_size(64 * 1024 * 1024),
                 )
                 .serve_with_incoming_shutdown(
                     tokio_stream::wrappers::TcpListenerStream::new(listener),
@@ -86,10 +80,9 @@ impl PluginServer {
         tx
     }
 
-    fn new(log_level_filter: log::LevelFilter) -> Self {
+    fn new() -> Self {
         Self {
             event_queue: EventQueue::instance(),
-            log_level_filter,
         }
     }
 }
@@ -144,33 +137,19 @@ impl omni_led_api::types::plugin_server::Plugin for PluginServer {
         Ok(Response::new(EventResponse {}))
     }
 
-    async fn log(
-        &self,
-        request: Request<Streaming<LogData>>,
-    ) -> Result<Response<LogResponse>, Status> {
-        let mut in_stream = request.into_inner();
+    async fn log(&self, request: Request<LogData>) -> Result<Response<LogResponse>, Status> {
+        let data = request.get_ref();
 
-        tokio::spawn(async move {
-            while let Some(result) = in_stream.next().await {
-                match result {
-                    Ok(data) => match data.log_level() {
-                        LogLevel::Unknown => {
-                            debug!(target: &data.location, "Received unknown log level. Original log message: '{}'", data.message)
-                        }
-                        level => {
-                            log!(target: &data.location, level.into(), "{}", data.message);
-                        }
-                    },
-                    Err(status) => {
-                        debug!("Connection closed: {}", status);
-                        break;
-                    }
-                }
+        let location = format!("plugin::{}", data.location);
+        match data.log_level() {
+            LogLevel::Unknown => {
+                error!(target: &location, "Received unknown log level. Original log message: '{}'", data.message)
             }
-        });
+            level => {
+                log!(target: &location, level.into(), "{}", data.message);
+            }
+        };
 
-        let mut response = LogResponse::default();
-        response.set_log_level_filter(self.log_level_filter.into());
-        Ok(Response::new(response))
+        Ok(Response::new(LogResponse {}))
     }
 }

--- a/omni-led/src/logging.rs
+++ b/omni-led/src/logging.rs
@@ -1,5 +1,6 @@
 use log::{LevelFilter, error};
 use log4rs::append::file::FileAppender;
+use log4rs::config::runtime::ConfigBuilder;
 use log4rs::config::{Appender, Root};
 use log4rs::encode::pattern::PatternEncoder;
 use log4rs::{Config, Handle};
@@ -38,28 +39,44 @@ pub fn init(lua: &Lua) -> OmniLedLogHandle {
 }
 
 fn create_config(file_path: impl AsRef<Path>, level_filter: LevelFilter) -> Config {
+    const LOGFILE: &str = "logfile";
+
     let logfile = FileAppender::builder()
         .encoder(Box::new(PatternEncoder::new(
             "[{d(%Y-%m-%d %H:%M:%S:%3f)}][{l}][{t}] {m}\n",
         )))
         .build(file_path)
         .unwrap();
-    let config = Config::builder()
-        .appender(Appender::builder().build("logfile", Box::new(logfile)))
-        .logger(log4rs::config::Logger::builder().build("hyper", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("mio", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("naga", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("rustls", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("tracing", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("ureq", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("ureq_proto", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("warp", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("wgpu_core", LevelFilter::Error))
-        .logger(log4rs::config::Logger::builder().build("wgpu_hal", LevelFilter::Error))
-        .build(Root::builder().appender("logfile").build(level_filter))
-        .unwrap();
 
-    config
+    let add_config = |builder: ConfigBuilder, name: &'static str| -> ConfigBuilder {
+        builder.logger(
+            log4rs::config::Logger::builder()
+                .appender(LOGFILE)
+                .additive(false)
+                .build(name, level_filter),
+        )
+    };
+
+    let builder = Config::builder().appender(Appender::builder().build(LOGFILE, Box::new(logfile)));
+
+    // OmniLED implementation files
+    let builder = add_config(builder, "omni_led");
+    let builder = add_config(builder, "omni_led_api");
+    let builder = add_config(builder, "omni_led_lib");
+
+    // Script files (+ 'script' as fallback if it failed to get script name)
+    let builder = add_config(builder, "applications.lua");
+    let builder = add_config(builder, "devices.lua");
+    let builder = add_config(builder, "scripts.lua");
+    let builder = add_config(builder, "settings.lua");
+    let builder = add_config(builder, "script");
+
+    // Plugin applications
+    let builder = add_config(builder, "plugin");
+
+    builder
+        .build(Root::builder().appender(LOGFILE).build(LevelFilter::Error))
+        .unwrap()
 }
 
 #[cfg(debug_assertions)]


### PR DESCRIPTION
Make all crates log only errors by default, and then explicitly enable logging for desired crates.

Breaking change:
Now the 'log' gRPC message returns to a regular message instead of being a stream