### PR TITLE
User script events

### DIFF
--- a/docs/scripting_reference.md
+++ b/docs/scripting_reference.md
@@ -460,6 +460,15 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 
 ---
 
+> ### `marked_table`
+>
+> Type: `fn(table: table) -> table`
+>
+> Sets a metatable that marks this table as a key-value table.
+> Returns the passed table for convenience.
+
+---
+
 > ### `raw_usb_device`
 >
 > Type: `fn(settings: RawUsbDeviceSettings)`
@@ -524,6 +533,25 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 > > `unregister: fn(self, handle: EventHandle)`
 > >
 > > Unregister from an event using a handle received when registering.
+>
+> > `send: fn(self, event: string, value: any)`
+> >
+> > Send any event from user scripts. Due to lua limitations, for
+> > [recursive updates](user_scripts.md#application_update_events) each table must be marked using `marked_table`
+> > function.
+> >
+> > `event` must only consist of uppercase aplhanumeric characters and cannot start with a number.
+> >
+> > Example
+> >
+> > ```lua
+> > EVENTS:send('MY_EVENT', marked_table {
+> >   Data = 1,
+> >   Nested = marked_table {
+> >     MoreData = 2,
+> >   },
+> > }
+> > ```
 
 ---
 

--- a/omni-led-lib/src/common/common.rs
+++ b/omni-led-lib/src/common/common.rs
@@ -18,6 +18,7 @@ macro_rules! create_table_with_defaults {
                 new_table.dump = internal.dump
                 new_table.getmetatable = getmetatable
                 new_table.ipairs = ipairs
+                new_table.marked_table = internal.marked_table
                 new_table.math = internal.table_copy(math)
                 new_table.math.round = internal.round
                 new_table.next = next
@@ -55,6 +56,10 @@ pub fn load_internal_functions(lua: &Lua) {
         })
         .unwrap();
 
+    let marked_table = lua
+        .create_function(|lua, table: Table| crate::events::proto_to_lua::marked_table(lua, table))
+        .unwrap();
+
     let round = lua
         .create_function(|_, value: f64| {
             let value = value.round() as i64;
@@ -78,6 +83,7 @@ pub fn load_internal_functions(lua: &Lua) {
             "internal",
             create_table!(lua, {
                 dump = $dump,
+                marked_table = $marked_table,
                 round = $round,
                 table_copy = $table_copy
             }),

--- a/omni-led-lib/src/events/dispatcher.rs
+++ b/omni-led-lib/src/events/dispatcher.rs
@@ -36,6 +36,9 @@ impl Dispatcher {
             Event::Register(event_entry) => self.register(event_entry),
             Event::Unregister(event_handle) => self.unregister(event_handle),
             Event::ClearUserEvents => self.clear_non_persistent(),
+            Event::Script(script_event) => {
+                self.dispatch_application_event(&script_event.event, script_event.value, None)
+            }
         }
     }
 

--- a/omni-led-lib/src/events/dispatcher.rs
+++ b/omni-led-lib/src/events/dispatcher.rs
@@ -1,0 +1,114 @@
+use log::warn;
+use mlua::{ErrorContext, Lua, Value};
+use omni_led_api::types::{Field, field};
+
+use crate::events::event_handle::EventHandle;
+use crate::events::event_queue::Event;
+use crate::events::events::EventEntry;
+use crate::events::proto_to_lua::{get_cleanup_entries_metatable, proto_to_lua_value};
+use crate::keyboard::keyboard::{KeyboardEvent, KeyboardEventEventType};
+
+pub struct Dispatcher {
+    entries: Vec<EventEntry>,
+    counter: usize,
+}
+
+impl Dispatcher {
+    pub fn load(_lua: &Lua) -> Self {
+        Self {
+            entries: Vec::new(),
+            counter: 0,
+        }
+    }
+
+    pub fn dispatch(&mut self, lua: &Lua, event: Event) -> mlua::Result<()> {
+        match event {
+            Event::Application((application, value)) => {
+                let value = Field {
+                    field: Some(field::Field::FTable(value)),
+                };
+                let value = proto_to_lua_value(&lua, value)
+                    .map_err(|err| err.with_context(|_| "Failed to convert protobuf value"))?;
+
+                self.dispatch_application_event(&application, value, None)
+            }
+            Event::Keyboard(event) => self.dispatch_keyboard_event(lua, event),
+            Event::Register(event_entry) => self.register(event_entry),
+            Event::Unregister(event_handle) => self.unregister(event_handle),
+            Event::ClearUserEvents => self.clear_non_persistent(),
+        }
+    }
+
+    fn register(&mut self, entry: EventEntry) -> mlua::Result<()> {
+        self.counter += 1;
+        entry.handle.assign_id(self.counter);
+        self.entries.push(entry);
+        Ok(())
+    }
+
+    fn unregister(&mut self, handle: EventHandle) -> mlua::Result<()> {
+        match self.entries.iter().position(|entry| entry.handle == handle) {
+            Some(index) => {
+                self.entries.remove(index);
+            }
+            None => {
+                warn!(
+                    "Failed to unregister event. Key {} not found",
+                    handle.get_id()
+                );
+            }
+        };
+        Ok(())
+    }
+
+    fn clear_non_persistent(&mut self) -> mlua::Result<()> {
+        self.entries.retain(|entry| entry.persistent);
+        Ok(())
+    }
+
+    fn dispatch_application_event(
+        &self,
+        value_name: &str,
+        value: Value,
+        current_key: Option<&str>,
+    ) -> mlua::Result<()> {
+        let current_key = match current_key {
+            Some(current_key) => format!("{}.{}", current_key, value_name),
+            None => value_name.to_string(),
+        };
+
+        self.dispatch_event(&current_key, &value)?;
+
+        if let Value::Table(table) = value {
+            if let Some(_) = get_cleanup_entries_metatable(&table)? {
+                return table.for_each(|key: String, val: Value| {
+                    self.dispatch_application_event(&key, val, Some(&current_key))
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn dispatch_keyboard_event(&self, lua: &Lua, event: KeyboardEvent) -> mlua::Result<()> {
+        let key_name = format!("KEY({})", event.key);
+        let action = match event.event_type {
+            KeyboardEventEventType::Press => "Pressed",
+            KeyboardEventEventType::Release => "Released",
+        };
+        let action = Value::String(lua.create_string(action)?);
+
+        self.dispatch_event(&key_name, &action)
+    }
+
+    fn dispatch_event(&self, event: &str, value: &Value) -> mlua::Result<()> {
+        for entry in &self.entries {
+            if entry.key.matches(event) {
+                entry
+                    .on_match
+                    .call::<()>((event.to_string(), value.clone()))?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/omni-led-lib/src/events/event_handle.rs
+++ b/omni-led-lib/src/events/event_handle.rs
@@ -1,0 +1,46 @@
+use mlua::{FromLua, Lua, UserData, Value};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::common::lua_traits::{FromUserdata, LuaName};
+
+#[derive(Clone)]
+pub struct EventHandle {
+    event_id: Arc<AtomicUsize>,
+}
+
+impl EventHandle {
+    pub fn new() -> Self {
+        Self {
+            event_id: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub fn assign_id(&self, event_id: usize) {
+        self.event_id.store(event_id, Ordering::Relaxed);
+    }
+
+    pub fn get_id(&self) -> usize {
+        self.event_id.load(Ordering::Relaxed)
+    }
+}
+
+impl PartialEq for EventHandle {
+    fn eq(&self, other: &EventHandle) -> bool {
+        self.get_id() == other.get_id()
+    }
+}
+
+impl UserData for EventHandle {}
+
+impl LuaName for EventHandle {
+    const NAME: &str = "EventHandle";
+}
+
+impl FromUserdata for EventHandle {}
+
+impl FromLua for EventHandle {
+    fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+        Self::from_userdata(lua, value)
+    }
+}

--- a/omni-led-lib/src/events/event_queue.rs
+++ b/omni-led-lib/src/events/event_queue.rs
@@ -2,6 +2,7 @@ use lazy_static::lazy_static;
 use omni_led_api::types::Table;
 use std::sync::{Arc, Mutex};
 
+use crate::events::{event_handle::EventHandle, events::EventEntry};
 use crate::keyboard::keyboard::KeyboardEvent;
 
 type ApplicationEvent = (String, Table);
@@ -9,20 +10,22 @@ type ApplicationEvent = (String, Table);
 pub enum Event {
     Application(ApplicationEvent),
     Keyboard(KeyboardEvent),
+    Register(EventEntry),
+    Unregister(EventHandle),
+    ClearUserEvents,
 }
 
 pub struct EventQueue {
     queue: Vec<Event>,
+    front: usize,
     counter: u64,
 }
 
 impl EventQueue {
     pub fn instance() -> Arc<Mutex<EventQueue>> {
         lazy_static! {
-            static ref UPDATE_HANDLER: Arc<Mutex<EventQueue>> = Arc::new(Mutex::new(EventQueue {
-                queue: Vec::new(),
-                counter: 0
-            }));
+            static ref UPDATE_HANDLER: Arc<Mutex<EventQueue>> =
+                Arc::new(Mutex::new(EventQueue::new()));
         }
 
         Arc::clone(&*UPDATE_HANDLER)
@@ -32,20 +35,34 @@ impl EventQueue {
         self.queue.push(event);
     }
 
+    pub fn push_front(&mut self, event: Event) {
+        self.queue.insert(self.front, event);
+        self.front += 1;
+    }
+
     pub fn get_events(&mut self) -> Vec<Event> {
-        let mut events: Vec<Event> = self.get_default_event_queue();
+        self.front = 0;
+        self.counter += 1;
+
+        let mut events: Vec<Event> = Self::get_default_event_queue(self.counter);
         std::mem::swap(&mut events, &mut self.queue);
+
         events
     }
 
-    fn get_default_event_queue(&mut self) -> Vec<Event> {
+    fn new() -> Self {
+        Self {
+            queue: Self::get_default_event_queue(0),
+            front: 0,
+            counter: 0,
+        }
+    }
+
+    fn get_default_event_queue(counter: u64) -> Vec<Event> {
         // TODO find a better way to register meta events
 
         let mut table = Table::default();
-        table
-            .items
-            .insert("Update".to_string(), self.counter.into());
-        self.counter += 1;
+        table.items.insert("Update".to_string(), counter.into());
 
         vec![Event::Application(("OMNILED".to_string(), table))]
     }

--- a/omni-led-lib/src/events/event_queue.rs
+++ b/omni-led-lib/src/events/event_queue.rs
@@ -2,6 +2,7 @@ use lazy_static::lazy_static;
 use omni_led_api::types::Table;
 use std::sync::{Arc, Mutex};
 
+use crate::events::events::ScriptEvent;
 use crate::events::{event_handle::EventHandle, events::EventEntry};
 use crate::keyboard::keyboard::KeyboardEvent;
 
@@ -13,6 +14,7 @@ pub enum Event {
     Register(EventEntry),
     Unregister(EventHandle),
     ClearUserEvents,
+    Script(ScriptEvent),
 }
 
 pub struct EventQueue {

--- a/omni-led-lib/src/events/events.rs
+++ b/omni-led-lib/src/events/events.rs
@@ -1,31 +1,14 @@
 use log::warn;
-use mlua::{ErrorContext, FromLua, Function, Lua, UserData, UserDataMethods, Value};
+use mlua::{ErrorContext, Function, Lua, UserData, UserDataMethods, Value};
 use omni_led_api::types::{Field, field};
 use omni_led_derive::UniqueUserData;
 
-use crate::common::lua_traits::{FromUserdata, LuaName};
 use crate::common::user_data::UniqueUserData;
+use crate::events::event_handle::EventHandle;
 use crate::events::event_queue::Event;
 use crate::events::proto_to_lua::{get_cleanup_entries_metatable, proto_to_lua_value};
 use crate::keyboard::keyboard::{KeyboardEvent, KeyboardEventEventType};
 use crate::script_handler::script_data_types::EventKey;
-
-#[derive(Clone, Copy, PartialEq)]
-pub struct EventHandle(usize);
-
-impl UserData for EventHandle {}
-
-impl LuaName for EventHandle {
-    const NAME: &str = "EventHandle";
-}
-
-impl FromUserdata for EventHandle {}
-
-impl FromLua for EventHandle {
-    fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
-        Self::from_userdata(lua, value)
-    }
-}
 
 struct EventEntry {
     key: EventKey,
@@ -37,7 +20,6 @@ struct EventEntry {
 #[derive(UniqueUserData)]
 pub struct Events {
     entries: Vec<EventEntry>,
-    counter: usize,
 }
 
 impl Events {
@@ -46,20 +28,18 @@ impl Events {
             lua,
             Self {
                 entries: Vec::new(),
-                counter: 0,
             },
         );
     }
 
     pub fn register(&mut self, key: EventKey, on_match: Function, persistent: bool) -> EventHandle {
-        self.counter += 1;
-        let handle = EventHandle(self.counter);
+        let handle = EventHandle::new();
 
         self.entries.push(EventEntry {
             key: key.into(),
             on_match,
             persistent,
-            handle,
+            handle: handle.clone(),
         });
 
         handle
@@ -71,7 +51,10 @@ impl Events {
                 self.entries.remove(index);
             }
             None => {
-                warn!("Failed to unregister event. Key {} not found", handle.0);
+                warn!(
+                    "Failed to unregister event. Key {} not found",
+                    handle.get_id()
+                );
             }
         };
         Ok(())

--- a/omni-led-lib/src/events/events.rs
+++ b/omni-led-lib/src/events/events.rs
@@ -1,20 +1,10 @@
-use mlua::{Function, Lua, UserData, UserDataMethods};
+use mlua::{Function, Lua, UserData, UserDataMethods, Value};
 use omni_led_derive::UniqueUserData;
 
 use crate::common::user_data::UniqueUserData;
 use crate::events::event_handle::EventHandle;
 use crate::events::event_queue::{Event, EventQueue};
 use crate::script_handler::script_data_types::EventKey;
-
-pub struct EventEntry {
-    pub key: EventKey,
-    pub on_match: Function,
-    pub handle: EventHandle,
-    pub persistent: bool,
-}
-
-// SAFETY: This struct will always be created and read from lua interpreter thread
-unsafe impl Send for EventEntry {}
 
 #[derive(UniqueUserData)]
 pub struct Events;
@@ -33,26 +23,25 @@ impl Events {
             handle: handle.clone(),
         };
 
-        EventQueue::instance()
-            .lock()
-            .unwrap()
-            .push_front(Event::Register(entry));
+        Self::queue_event(Event::Register(entry));
 
         handle
     }
 
     pub fn unregister(handle: EventHandle) {
-        EventQueue::instance()
-            .lock()
-            .unwrap()
-            .push_front(Event::Unregister(handle));
+        Self::queue_event(Event::Unregister(handle));
     }
 
     pub fn clear_non_persistent() {
-        EventQueue::instance()
-            .lock()
-            .unwrap()
-            .push_front(Event::ClearUserEvents);
+        Self::queue_event(Event::ClearUserEvents);
+    }
+
+    pub fn send(event: String, value: Value) {
+        Self::queue_event(Event::Script(ScriptEvent { event, value }));
+    }
+
+    fn queue_event(event: Event) {
+        EventQueue::instance().lock().unwrap().push_front(event);
     }
 }
 
@@ -69,5 +58,27 @@ impl UserData for Events {
         methods.add_method("unregister", |_lua, _this, handle: EventHandle| {
             Ok(Self::unregister(handle))
         });
+
+        methods.add_method("send", |_lua, _this, (event, value): (String, Value)| {
+            Ok(Self::send(event, value))
+        });
     }
 }
+
+pub struct EventEntry {
+    pub key: EventKey,
+    pub on_match: Function,
+    pub handle: EventHandle,
+    pub persistent: bool,
+}
+
+// SAFETY: This struct will always be created and read from lua interpreter thread
+unsafe impl Send for EventEntry {}
+
+pub struct ScriptEvent {
+    pub event: String,
+    pub value: Value,
+}
+
+// SAFETY: This struct will always be created and read from lua interpreter thread
+unsafe impl Send for ScriptEvent {}

--- a/omni-led-lib/src/events/events.rs
+++ b/omni-led-lib/src/events/events.rs
@@ -1,4 +1,6 @@
+use log::error;
 use mlua::{Function, Lua, UserData, UserDataMethods, Value};
+use omni_led_api::plugin::Plugin;
 use omni_led_derive::UniqueUserData;
 
 use crate::common::user_data::UniqueUserData;
@@ -37,7 +39,11 @@ impl Events {
     }
 
     pub fn send(event: String, value: Value) {
-        Self::queue_event(Event::Script(ScriptEvent { event, value }));
+        if Plugin::is_valid_identifier(&event) {
+            Self::queue_event(Event::Script(ScriptEvent { event, value }));
+        } else {
+            error!("'{event}' is not a valid event name");
+        }
     }
 
     fn queue_event(event: Event) {

--- a/omni-led-lib/src/events/events.rs
+++ b/omni-led-lib/src/events/events.rs
@@ -1,143 +1,73 @@
-use log::warn;
-use mlua::{ErrorContext, Function, Lua, UserData, UserDataMethods, Value};
-use omni_led_api::types::{Field, field};
+use mlua::{Function, Lua, UserData, UserDataMethods};
 use omni_led_derive::UniqueUserData;
 
 use crate::common::user_data::UniqueUserData;
 use crate::events::event_handle::EventHandle;
-use crate::events::event_queue::Event;
-use crate::events::proto_to_lua::{get_cleanup_entries_metatable, proto_to_lua_value};
-use crate::keyboard::keyboard::{KeyboardEvent, KeyboardEventEventType};
+use crate::events::event_queue::{Event, EventQueue};
 use crate::script_handler::script_data_types::EventKey;
 
-struct EventEntry {
-    key: EventKey,
-    on_match: Function,
-    handle: EventHandle,
-    persistent: bool,
+pub struct EventEntry {
+    pub key: EventKey,
+    pub on_match: Function,
+    pub handle: EventHandle,
+    pub persistent: bool,
 }
 
+// SAFETY: This struct will always be created and read from lua interpreter thread
+unsafe impl Send for EventEntry {}
+
 #[derive(UniqueUserData)]
-pub struct Events {
-    entries: Vec<EventEntry>,
-}
+pub struct Events;
 
 impl Events {
     pub fn load(lua: &Lua) {
-        Self::set_unique(
-            lua,
-            Self {
-                entries: Vec::new(),
-            },
-        );
+        Self::set_unique(lua, Self);
     }
 
-    pub fn register(&mut self, key: EventKey, on_match: Function, persistent: bool) -> EventHandle {
+    pub fn register(key: EventKey, on_match: Function, persistent: bool) -> EventHandle {
         let handle = EventHandle::new();
-
-        self.entries.push(EventEntry {
+        let entry = EventEntry {
             key: key.into(),
             on_match,
             persistent,
             handle: handle.clone(),
-        });
+        };
+
+        EventQueue::instance()
+            .lock()
+            .unwrap()
+            .push_front(Event::Register(entry));
 
         handle
     }
 
-    pub fn unregister(&mut self, handle: EventHandle) -> mlua::Result<()> {
-        match self.entries.iter().position(|entry| entry.handle == handle) {
-            Some(index) => {
-                self.entries.remove(index);
-            }
-            None => {
-                warn!(
-                    "Failed to unregister event. Key {} not found",
-                    handle.get_id()
-                );
-            }
-        };
-        Ok(())
+    pub fn unregister(handle: EventHandle) {
+        EventQueue::instance()
+            .lock()
+            .unwrap()
+            .push_front(Event::Unregister(handle));
     }
 
-    pub fn clear_non_persistent(&mut self) {
-        self.entries.retain(|entry| entry.persistent);
-    }
-
-    pub fn dispatch(&self, lua: &Lua, event: Event) -> mlua::Result<()> {
-        match event {
-            Event::Application((application, value)) => {
-                let value = Field {
-                    field: Some(field::Field::FTable(value)),
-                };
-                let value = proto_to_lua_value(&lua, value)
-                    .map_err(|err| err.with_context(|_| "Failed to convert protobuf value"))?;
-
-                self.dispatch_application_event(&application, value, None)
-            }
-            Event::Keyboard(event) => self.dispatch_keyboard_event(lua, event),
-        }
-    }
-
-    fn dispatch_application_event(
-        &self,
-        value_name: &str,
-        value: Value,
-        current_key: Option<&str>,
-    ) -> mlua::Result<()> {
-        let current_key = match current_key {
-            Some(current_key) => format!("{}.{}", current_key, value_name),
-            None => value_name.to_string(),
-        };
-
-        self.dispatch_event(&current_key, &value)?;
-
-        if let Value::Table(table) = value {
-            if let Some(_) = get_cleanup_entries_metatable(&table)? {
-                return table.for_each(|key: String, val: Value| {
-                    self.dispatch_application_event(&key, val, Some(&current_key))
-                });
-            }
-        }
-
-        Ok(())
-    }
-
-    fn dispatch_keyboard_event(&self, lua: &Lua, event: KeyboardEvent) -> mlua::Result<()> {
-        let key_name = format!("KEY({})", event.key);
-        let action = match event.event_type {
-            KeyboardEventEventType::Press => "Pressed",
-            KeyboardEventEventType::Release => "Released",
-        };
-        let action = Value::String(lua.create_string(action)?);
-
-        self.dispatch_event(&key_name, &action)
-    }
-
-    fn dispatch_event(&self, event: &str, value: &Value) -> mlua::Result<()> {
-        for entry in &self.entries {
-            if entry.key.matches(event) {
-                entry
-                    .on_match
-                    .call::<()>((event.to_string(), value.clone()))?;
-            }
-        }
-        Ok(())
+    pub fn clear_non_persistent() {
+        EventQueue::instance()
+            .lock()
+            .unwrap()
+            .push_front(Event::ClearUserEvents);
     }
 }
 
 impl UserData for Events {
     fn add_methods<'lua, M: UserDataMethods<Self>>(methods: &mut M) {
-        methods.add_method_mut(
+        methods.add_method(
             "register",
-            |_lua, this, (key, on_match): (EventKey, Function)| {
+            |_lua, _this, (key, on_match): (EventKey, Function)| {
                 // Registering from user scripts must never be persistent to avoid issues on reloads
-                Ok(this.register(key, on_match, false))
+                Ok(Self::register(key, on_match, false))
             },
         );
 
-        methods.add_method_mut("unregister", |_lua, this, key: EventHandle| {
-            this.unregister(key)
+        methods.add_method("unregister", |_lua, _this, handle: EventHandle| {
+            Ok(Self::unregister(handle))
         });
     }
 }

--- a/omni-led-lib/src/events/mod.rs
+++ b/omni-led-lib/src/events/mod.rs
@@ -1,3 +1,4 @@
+pub mod event_handle;
 pub mod event_loop;
 pub mod event_queue;
 pub mod events;

--- a/omni-led-lib/src/events/mod.rs
+++ b/omni-led-lib/src/events/mod.rs
@@ -1,3 +1,4 @@
+pub mod dispatcher;
 pub mod event_handle;
 pub mod event_loop;
 pub mod event_queue;

--- a/omni-led-lib/src/events/proto_to_lua.rs
+++ b/omni-led-lib/src/events/proto_to_lua.rs
@@ -14,6 +14,17 @@ pub fn get_cleanup_entries_metatable(table: &Table) -> mlua::Result<Option<Table
     }
 }
 
+pub fn marked_table(lua: &Lua, table: Table) -> mlua::Result<Table> {
+    set_cleanup_entries_metatable(lua, &table, lua.create_table()?)?;
+    Ok(table)
+}
+
+fn set_cleanup_entries_metatable(lua: &Lua, table: &Table, entries: Table) -> mlua::Result<()> {
+    let meta = lua.create_table_with_capacity(0, 1)?;
+    meta.set(CLEANUP_ENTRIES, entries)?;
+    table.set_metatable(Some(meta))
+}
+
 pub fn proto_to_lua_value(lua: &Lua, field: Field) -> mlua::Result<Value> {
     match field.field {
         Some(FieldEntry::FNone(_)) | None => Ok(mlua::Nil),
@@ -45,9 +56,7 @@ pub fn proto_to_lua_value(lua: &Lua, field: Field) -> mlua::Result<Value> {
                 }
             }
 
-            let meta = lua.create_table_with_capacity(0, 1)?;
-            meta.set(CLEANUP_ENTRIES, cleanup_entries)?;
-            _ = table.set_metatable(Some(meta));
+            set_cleanup_entries_metatable(&lua, &table, cleanup_entries)?;
 
             Ok(Value::Table(table))
         }

--- a/omni-led-lib/src/events/shortcuts.rs
+++ b/omni-led-lib/src/events/shortcuts.rs
@@ -36,8 +36,7 @@ impl Shortcuts {
             })
             .unwrap();
 
-        let mut events = UserDataRef::<Events>::load(lua);
-        events.get_mut().register(
+        Events::register(
             EventKey::String("OMNILED.Update".to_string()),
             function,
             true,
@@ -152,11 +151,8 @@ impl Shortcuts {
                 Self::process_key(&mut entry, &key, &action, current_tick)
             })?;
 
-        let mut events = UserDataRef::<Events>::load(lua);
         for key in keys {
-            events
-                .get_mut()
-                .register(EventKey::String(key), function.clone(), false);
+            Events::register(EventKey::String(key), function.clone(), false);
         }
 
         Ok(())

--- a/omni-led-lib/src/script_handler/script_handler.rs
+++ b/omni-led-lib/src/script_handler/script_handler.rs
@@ -67,12 +67,8 @@ impl ScriptHandler {
             })
             .unwrap();
 
-        let mut events = UserDataRef::<Events>::load(lua);
         let regex = Regex::new(".*").unwrap();
-        events
-            .get_mut()
-            .register(EventKey::Regex(regex), event_handler, true);
-        std::mem::drop(events);
+        Events::register(EventKey::Regex(regex), event_handler, true);
 
         load_config(lua, ConfigType::Scripts, &config, environment).unwrap();
     }

--- a/omni-led/src/main.rs
+++ b/omni-led/src/main.rs
@@ -9,6 +9,7 @@ use omni_led_lib::{
     constants::config::{ConfigType, read_config},
     constants::constants::Constants,
     devices::devices::Devices,
+    events::dispatcher::Dispatcher,
     events::event_loop::EventLoop,
     events::events::Events,
     events::shortcuts::Shortcuts,
@@ -63,6 +64,7 @@ fn main() {
 
         Settings::load(&lua, settings_config);
         let server_shutdown_tx = PluginServer::load(&lua, &rt);
+        let mut dispatcher = Dispatcher::load(&lua);
         Events::load(&lua);
         Shortcuts::load(&lua);
         Devices::load(&lua, devices_config);
@@ -76,9 +78,8 @@ fn main() {
         let interval = settings.get().update_interval;
         let event_loop = EventLoop::new();
         event_loop.run(interval, &RUNNING, |events| {
-            let dispatcher = UserDataRef::<Events>::load(&lua);
             for event in events {
-                dispatcher.get().dispatch(&lua, event).unwrap();
+                dispatcher.dispatch(&lua, event).unwrap();
             }
 
             let mut script_handler = UserDataRef::<ScriptHandler>::load(&lua);


### PR DESCRIPTION
Adds ability to send user-defined events from lua scripts.

Breaking changes:
- `EVENTS:register` and `EVENTS:unregister` now run at the beginning of the next update iteration (before any incoming application and keyboard events).  Before they were executed immediately.