### PR TITLE
More strong types in scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3851,6 +3851,7 @@ dependencies = [
  "freetype-rs",
  "gtk",
  "hidapi",
+ "humantime",
  "image",
  "lazy_static",
  "libc",
@@ -5480,6 +5481,7 @@ version = "0.9.1"
 dependencies = [
  "all-smi",
  "clap",
+ "humantime",
  "log",
  "omni-led-api",
  "omni-led-derive",
@@ -6541,6 +6543,7 @@ version = "0.9.1"
 dependencies = [
  "chrono",
  "clap",
+ "humantime",
  "image",
  "log",
  "omni-led-api",

--- a/config/applications.lua
+++ b/config/applications.lua
@@ -21,7 +21,7 @@ load_app {
     path = get_default_path('system'),
     args = {
         '--address', SERVER.Address,
-        '--interval', 2,
+        '--interval', '2sec',
     },
 }
 
@@ -29,7 +29,7 @@ load_app {
     path = get_default_path('weather'),
     args = {
         '--address', SERVER.Address,
-        '--interval', 10,
+        '--interval', '10min',
         '--wind-speed-unit', 'm/s',
         '--temperature-unit', 'Celsius',
         'in', 'Warsaw',

--- a/config/scripts.lua
+++ b/config/scripts.lua
@@ -33,7 +33,7 @@ local function volume()
     display_device(widgets, SCREEN.Height / 2, AUDIO.Input, 'input')
     return {
         widgets = widgets,
-        duration = 2000,
+        duration = Duration.from_secs(2),
     }
 end
 
@@ -76,7 +76,7 @@ local function media(source)
                 size = { width = SCREEN.Width, height = 2 },
             },
         },
-        duration = 1000,
+        duration = Duration.from_secs(1),
     }
 end
 
@@ -109,7 +109,7 @@ local function clock()
                 size = { width = SCREEN.Width, height = 2 },
             }
         },
-        duration = 1000,
+        duration = Duration.from_secs(1),
     }
 end
 
@@ -155,7 +155,7 @@ local function weather()
                 size = { width = SCREEN.Width, height = 2 },
             },
         },
-        duration = 1000,
+        duration = Duration.from_secs(1),
     }
 end
 
@@ -188,7 +188,7 @@ local function system()
                 size = { width = SCREEN.Width, height = SCREEN.Height / 3 },
             },
         },
-        duration = 1000,
+        duration = Duration.from_secs(1),
     }
 end
 

--- a/config/scripts.lua
+++ b/config/scripts.lua
@@ -170,13 +170,13 @@ local function system()
     return {
         widgets = {
             Widget.Text {
-                text = string.format('CPU: %.2f%% %02d°C', cpu.Utilization, cpu.Temperature or 0),
+                text = string.format('CPU: %.1f%% %d°%s', cpu.Utilization, math.round(cpu.Temperature or 0), SYSTEM.TemperatureUnit),
                 font_size = 13,
                 position = { x = 0, y = 0 },
                 size = { width = SCREEN.Width, height = SCREEN.Height / 3 },
             },
             Widget.Text {
-                text = string.format('GPU: %.2f%% %02d°C', gpu.Utilization, gpu.Temperature),
+                text = string.format('GPU: %.1f%% %d°%s', gpu.Utilization, math.round(gpu.Temperature), SYSTEM.TemperatureUnit),
                 font_size = 13,
                 position = { x = 0, y = SCREEN.Height / 3 },
                 size = { width = SCREEN.Width, height = SCREEN.Height / 3 },

--- a/config/settings.lua
+++ b/config/settings.lua
@@ -6,5 +6,5 @@ Settings {
     server_port = 0,
     text_ticks_scroll_delay = 8,
     text_ticks_repeat_delay = 2,
-    update_interval = 100,
+    update_interval = Duration.from_millis(100),
 }

--- a/docs/scripting_reference.md
+++ b/docs/scripting_reference.md
@@ -503,6 +503,48 @@ Enum variants marked with _implicit contruct_ can be used to implicitly construc
 
 ---
 
+> ### `Duration`
+>
+> Create strongly typed duration objects.
+>
+> > `from_nanos`: `fn(value: integer) -> Duration`  
+> > `from_micros`: `fn(value: integer) -> Duration`  
+> > `from_millis`: `fn(value: integer) -> Duration`  
+> > `from_secs`: `fn(value: integer) -> Duration`  
+> > `from_mins`: `fn(value: integer) -> Duration`  
+> > `from_hours`: `fn(value: integer) -> Duration`  
+> >
+> > Creates a new duration object from given value and time unit.
+>
+> > `MAX`: `Duration`
+> >
+> > Constant with the maximum duration value.
+>
+> > `MIN`: `Duration`
+> >
+> > Constant with the minimum (zero) duration value.
+>
+> > `as_nanos`: `fn(self) -> integer`  
+> > `as_micros`: `fn(self) -> integer`  
+> > `as_millis`: `fn(self) -> integer`  
+> > `as_secs`: `fn(self) -> integer`  
+> >
+> > Returns the duration truncated to a given time unit.
+>
+> > `__add`: `fn(lhs: Duration, rhs: Duration) -> Duration`
+> >
+> > "Add" metamethod. Duration will never overflow, instead will be capped at `Duration.MAX`
+>
+> > `__sub`: `fn(lhs: Duration, rhs: Duration) -> Duration`
+> >
+> > "Sub" metamethod. Duration will never underflow, instead will be capped at `Duration.ZERO`
+>
+> > _This type supports all relational operators._
+> >
+> > _This type can be stringified (representation is compatible with string format expected by OmniLED applications)._
+
+---
+
 > ### `Regex`
 >
 > Used to check if a string matches a regex pattern

--- a/omni-led-api/src/cli_types.rs
+++ b/omni-led-api/src/cli_types.rs
@@ -1,0 +1,40 @@
+#[derive(Clone, Copy)]
+pub enum TemperatureUnit {
+    Celsius,
+    Fahrenheit,
+}
+
+impl TemperatureUnit {
+    pub const fn name(self) -> &'static str {
+        match self {
+            TemperatureUnit::Celsius => "Celsius",
+            TemperatureUnit::Fahrenheit => "Fahrenheit",
+        }
+    }
+
+    pub const fn unit(self) -> char {
+        match self {
+            TemperatureUnit::Celsius => 'C',
+            TemperatureUnit::Fahrenheit => 'F',
+        }
+    }
+}
+
+impl From<&str> for TemperatureUnit {
+    fn from(value: &str) -> Self {
+        match value {
+            "C" | "Celsius" => Self::Celsius,
+            "F" | "Fahrenheit" => Self::Fahrenheit,
+            _ => unreachable!("Should have been validated by clap by this time"),
+        }
+    }
+}
+
+impl From<String> for TemperatureUnit {
+    fn from(value: String) -> Self {
+        Self::from(value.as_str())
+    }
+}
+
+pub const TEMPERATURE_UNIT_OPTIONS: [&str; 4] = ["C", "Celsius", "F", "Fahrenheit"];
+pub const TEMPERATURE_UNIT_DEFAULT: &str = TemperatureUnit::Celsius.name();

--- a/omni-led-api/src/lib.rs
+++ b/omni-led-api/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cli_types;
 pub mod plugin;
 pub mod types;
 

--- a/omni-led-api/src/types.rs
+++ b/omni-led-api/src/types.rs
@@ -86,6 +86,14 @@ impl Into<Field> for &str {
     }
 }
 
+impl Into<Field> for char {
+    fn into(self) -> Field {
+        Field {
+            field: Some(field::Field::FString(self.to_string())),
+        }
+    }
+}
+
 // Array values
 into_field!(Array, field::Field::FArray);
 

--- a/omni-led-applications/system/Cargo.toml
+++ b/omni-led-applications/system/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 [dependencies]
 all-smi = "0.20"
 clap = { version = "4.5", features = ["derive"] }
+humantime = "2.3"
 log = { version = "0.4", features = ["std"] }
 omni-led-api = { path = "../../omni-led-api" }
 omni-led-derive = { path = "../../omni-led-derive", features = ["into-proto"] }

--- a/omni-led-applications/system/README.md
+++ b/omni-led-applications/system/README.md
@@ -9,7 +9,7 @@ System application provides information about the following system resources:
 ## Running
 
 ```shell
-media --address <ADDRESS> [--interval <SECONDS>]
+media --address <ADDRESS> [--interval <TIME_STRING>]
 ```
 
 Media expects three arguments
@@ -17,8 +17,8 @@ Media expects three arguments
 - Required:
   - `a`/`address` - server address
 - Optional:
-  - `i`/`interval` - update interval in seconds.  
-    Default: `2`.
+  - `i`/`interval` - update interval  
+    Default: `2sec`.
   
 ## Available information
 

--- a/omni-led-applications/system/README.md
+++ b/omni-led-applications/system/README.md
@@ -1,4 +1,4 @@
-# Systen
+# System
 
 System application provides information about the following system resources:
 
@@ -19,6 +19,8 @@ Media expects three arguments
 - Optional:
   - `i`/`interval` - update interval  
     Default: `2sec`.
+  - `t`/`temperature-unit` - temperature unit ("C" | "Celsius" | "F" | "Fahrenheit")  
+    Default: `Celsius`
   
 ## Available information
 

--- a/omni-led-applications/system/src/cpu.rs
+++ b/omni-led-applications/system/src/cpu.rs
@@ -1,12 +1,15 @@
 use all_smi::{AllSmi, device::CoreType};
+use omni_led_api::cli_types::TemperatureUnit;
 use omni_led_derive::IntoProto;
+
+use crate::util::convert;
 
 #[derive(IntoProto)]
 #[proto(rename_all = PascalCase)]
 pub struct Data {
     name: String,
     utilization: f64,
-    temperature: Option<u32>,
+    temperature: Option<f64>,
     power_consumption: Option<f64>,
     cores: Vec<CoreData>,
 }
@@ -19,13 +22,15 @@ pub struct CoreData {
     r#type: &'static str,
 }
 
-pub fn read_data(smi: &AllSmi) -> Vec<Data> {
+pub fn read_data(smi: &AllSmi, temperature_unit: TemperatureUnit) -> Vec<Data> {
     smi.get_cpu_info()
         .into_iter()
         .map(|data| Data {
             name: data.cpu_model,
             utilization: data.utilization,
-            temperature: data.temperature,
+            temperature: data
+                .temperature
+                .and_then(|temperature| Some(convert(temperature, temperature_unit))),
             power_consumption: data.power_consumption,
             cores: data
                 .per_core_utilization

--- a/omni-led-applications/system/src/gpu.rs
+++ b/omni-led-applications/system/src/gpu.rs
@@ -1,25 +1,28 @@
 use all_smi::AllSmi;
+use omni_led_api::cli_types::TemperatureUnit;
 use omni_led_derive::IntoProto;
+
+use crate::util::convert;
 
 #[derive(IntoProto)]
 #[proto(rename_all = PascalCase)]
 pub struct Data {
     name: String,
     utilization: f64,
-    temperature: u32,
+    temperature: f64,
     power_consumption: f64,
     frequency: u32,
     used_memory: u64,
     total_memory: u64,
 }
 
-pub fn read_data(smi: &AllSmi) -> Vec<Data> {
+pub fn read_data(smi: &AllSmi, temperature_unit: TemperatureUnit) -> Vec<Data> {
     smi.get_gpu_info()
         .into_iter()
         .map(|data| Data {
             name: data.name,
             utilization: data.utilization,
-            temperature: data.temperature,
+            temperature: convert(data.temperature, temperature_unit),
             power_consumption: data.power_consumption,
             frequency: data.frequency,
             used_memory: data.used_memory,

--- a/omni-led-applications/system/src/main.rs
+++ b/omni-led-applications/system/src/main.rs
@@ -1,26 +1,32 @@
 use all_smi::AllSmi;
 use clap::Parser;
-use omni_led_api::new_plugin;
+use omni_led_api::{
+    cli_types::{TEMPERATURE_UNIT_DEFAULT, TEMPERATURE_UNIT_OPTIONS, TemperatureUnit},
+    new_plugin,
+};
 use omni_led_derive::IntoProto;
 use std::time::{Duration, Instant};
 
 mod cpu;
 mod gpu;
 mod mem;
+mod util;
 
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
     let plugin = new_plugin!(&options.address);
+    let temperature_unit: TemperatureUnit = options.temperature_unit.into();
 
     let smi = AllSmi::new().unwrap();
     loop {
         let begin = Instant::now();
 
         let data = SystemData {
-            cpus: cpu::read_data(&smi),
-            gpus: gpu::read_data(&smi),
+            cpus: cpu::read_data(&smi, temperature_unit),
+            gpus: gpu::read_data(&smi, temperature_unit),
             memory: mem::read_data(&smi),
+            temperature_unit: temperature_unit.unit(),
         };
         plugin.update(data.into()).await.unwrap();
 
@@ -37,6 +43,10 @@ struct Options {
     /// Interval between getting new system data
     #[clap(short, long, value_parser = humantime::parse_duration, default_value = "2sec")]
     interval: Duration,
+
+    /// Temperature unit
+    #[clap(short, long, value_parser = TEMPERATURE_UNIT_OPTIONS, default_value = TEMPERATURE_UNIT_DEFAULT)]
+    temperature_unit: String,
 }
 
 #[derive(IntoProto)]
@@ -45,4 +55,5 @@ struct SystemData {
     cpus: Vec<cpu::Data>,
     gpus: Vec<gpu::Data>,
     memory: Option<mem::Data>,
+    temperature_unit: char,
 }

--- a/omni-led-applications/system/src/main.rs
+++ b/omni-led-applications/system/src/main.rs
@@ -14,7 +14,6 @@ async fn main() {
     let plugin = new_plugin!(&options.address);
 
     let smi = AllSmi::new().unwrap();
-    let interval = Duration::from_secs(options.interval);
     loop {
         let begin = Instant::now();
 
@@ -25,7 +24,7 @@ async fn main() {
         };
         plugin.update(data.into()).await.unwrap();
 
-        tokio::time::sleep(interval.saturating_sub(begin.elapsed())).await;
+        tokio::time::sleep(options.interval.saturating_sub(begin.elapsed())).await;
     }
 }
 
@@ -35,9 +34,9 @@ struct Options {
     #[clap(short, long)]
     address: String,
 
-    /// Interval between getting new system data in seconds
-    #[clap(short, long, default_value = "2")]
-    interval: u64,
+    /// Interval between getting new system data
+    #[clap(short, long, value_parser = humantime::parse_duration, default_value = "2sec")]
+    interval: Duration,
 }
 
 #[derive(IntoProto)]

--- a/omni-led-applications/system/src/util.rs
+++ b/omni-led-applications/system/src/util.rs
@@ -1,0 +1,8 @@
+use omni_led_api::cli_types::TemperatureUnit;
+
+pub fn convert(temperature: u32, output_unit: TemperatureUnit) -> f64 {
+    match output_unit {
+        TemperatureUnit::Celsius => temperature as f64,
+        TemperatureUnit::Fahrenheit => temperature as f64 * 1.8 + 32.0,
+    }
+}

--- a/omni-led-applications/weather/Cargo.toml
+++ b/omni-led-applications/weather/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 [dependencies]
 chrono = { version = "0.4" }
 clap = { version = "4.5", features = ["derive"] }
+humantime = "2.3"
 image = "0.25"
 log = { version = "0.4", features = ["std"] }
 omni-led-api = { path = "../../omni-led-api" }

--- a/omni-led-applications/weather/src/main.rs
+++ b/omni-led-applications/weather/src/main.rs
@@ -1,9 +1,10 @@
+use std::time::Duration;
+
 use clap::Parser;
 use log::debug;
 use omni_led_api::types::Table;
 use omni_led_api::{new_plugin, plugin::Plugin};
 use omni_led_derive::IntoProto;
-use std::time;
 use ureq::Agent;
 
 mod weather_api;
@@ -28,7 +29,7 @@ async fn main() {
         let weather = weather_api::get_weather(&coordinates, name, &options);
         plugin.update(weather.into()).await.unwrap();
 
-        tokio::time::sleep(time::Duration::from_secs(options.interval * 60)).await;
+        tokio::time::sleep(options.interval).await;
     }
 }
 
@@ -158,9 +159,9 @@ struct Options {
     #[clap(short, long)]
     address: String,
 
-    /// Interval between getting new weather data in minutes
-    #[clap(short, long, default_value = "15")]
-    interval: u64,
+    /// Interval between getting new weather data
+    #[clap(short, long, value_parser = humantime::parse_duration, default_value = "15min")]
+    interval: Duration,
 
     /// Temperature unit
     #[clap(short, long, value_parser = ["C", "Celsius", "F", "Fahrenheit"], default_value = "Celsius")]

--- a/omni-led-applications/weather/src/main.rs
+++ b/omni-led-applications/weather/src/main.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use clap::Parser;
 use log::debug;
+use omni_led_api::cli_types::{TEMPERATURE_UNIT_DEFAULT, TEMPERATURE_UNIT_OPTIONS};
 use omni_led_api::types::Table;
 use omni_led_api::{new_plugin, plugin::Plugin};
 use omni_led_derive::IntoProto;
@@ -164,7 +165,7 @@ struct Options {
     interval: Duration,
 
     /// Temperature unit
-    #[clap(short, long, value_parser = ["C", "Celsius", "F", "Fahrenheit"], default_value = "Celsius")]
+    #[clap(short, long, value_parser = TEMPERATURE_UNIT_OPTIONS, default_value = TEMPERATURE_UNIT_DEFAULT)]
     temperature_unit: String,
 
     /// Wind speed unit

--- a/omni-led-applications/weather/src/weather_api.rs
+++ b/omni-led-applications/weather/src/weather_api.rs
@@ -1,6 +1,7 @@
 use chrono::Timelike;
 use image::codecs::png::PngEncoder;
 use image::{ExtendedColorType, ImageEncoder};
+use omni_led_api::cli_types::TemperatureUnit;
 use omni_led_api::types::{ImageData, ImageFormat};
 use serde::de;
 use std::collections::HashMap;
@@ -64,20 +65,12 @@ fn speed_unit_param(unit: &str) -> &'static str {
     }
 }
 
-fn temperature_unit_param(unit: &str) -> &'static str {
-    match unit {
-        "C" | "Celsius" => "celsius",
-        "F" | "Fahrenheit" => "fahrenheit",
-        _ => std::unreachable!(),
-    }
+fn temperature_unit_param(unit: &str) -> String {
+    TemperatureUnit::from(unit).name().to_ascii_lowercase()
 }
 
-fn temperature_unit_data(unit: &str) -> &'static str {
-    match unit {
-        "C" | "Celsius" => "C",
-        "F" | "Fahrenheit" => "F",
-        _ => std::unreachable!(),
-    }
+fn temperature_unit_data(unit: &str) -> String {
+    TemperatureUnit::from(unit).unit().to_string()
 }
 
 #[derive(serde::Deserialize)]

--- a/omni-led-derive/src/from_lua_value.rs
+++ b/omni-led-derive/src/from_lua_value.rs
@@ -11,7 +11,10 @@ pub fn expand_lua_value_derive(input: DeriveInput) -> proc_macro::TokenStream {
     let name = input.ident;
     let (_impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let struct_attrs = get_struct_attributes(&input.attrs);
-    let (initializer, handle_deprecated) = generate_initializer(&name, &input.data);
+
+    let impl_default = struct_attrs.impl_default.is_some();
+    let (initializer, handle_deprecated, default_initializer) =
+        generate_initializer(&name, &input.data, impl_default);
 
     let validate = match struct_attrs.validate {
         Some(validate) => quote! {
@@ -26,7 +29,7 @@ pub fn expand_lua_value_derive(input: DeriveInput) -> proc_macro::TokenStream {
         None => quote! { result },
     };
 
-    let expanded = quote! {
+    let mut expanded = quote! {
         impl FromLua for #name #ty_generics {
             fn from_lua(value: mlua::Value, lua: &mlua::Lua) -> mlua::Result<#name #ty_generics #where_clause> {
                 let result = match value {
@@ -47,16 +50,38 @@ pub fn expand_lua_value_derive(input: DeriveInput) -> proc_macro::TokenStream {
         }
     };
 
+    if let Some(default_initializer) = default_initializer {
+        expanded = quote! {
+            #expanded
+
+            impl Default for #name {
+                fn default() -> Self {
+                    Self {
+                        #default_initializer
+                        ..Default::default()
+                    }
+                }
+            }
+        }
+    }
+
     proc_macro::TokenStream::from(expanded)
 }
 
-fn generate_initializer(name: &Ident, data: &Data) -> (TokenStream, Option<TokenStream>) {
+fn generate_initializer(
+    name: &Ident,
+    data: &Data,
+    impl_default: bool,
+) -> (TokenStream, Option<TokenStream>, Option<TokenStream>) {
     match *data {
         Data::Struct(ref data) => match data.fields {
             syn::Fields::Named(ref fields) => {
                 let mut deprecated_field_handlers = Vec::new();
 
-                let names = fields.named.iter().map(|f| {
+                let mut names: Vec<TokenStream> = Vec::new();
+                let mut defaults: Vec<TokenStream> = Vec::new();
+
+                for f in &fields.named {
                     let field = &f.ident;
 
                     let attrs = get_field_attributes(&f.attrs);
@@ -104,11 +129,19 @@ fn generate_initializer(name: &Ident, data: &Data) -> (TokenStream, Option<Token
                         None => quote! { Ok(x) },
                     };
 
-                    let default = match (attrs.default, is_option(&f.ty)) {
+                    let default = match (attrs.default.clone(), is_option(&f.ty)) {
                         (Some(default), _) => quote! { Ok(#default) },
                         (None, true) => quote! { Ok(None) },
-                        (None, false) => quote! { Err(mlua::Error::runtime("Key not found".to_string())) },
+                        (None, false) => {
+                            quote! { Err(mlua::Error::runtime("Key not found".to_string())) }
+                        }
                     };
+
+                    if let Some(default) = attrs.default
+                        && impl_default
+                    {
+                        defaults.push(quote! { #field: #default, });
+                    }
 
                     let initializer = quote! {
                         table.get::<Option<_>>(stringify!(#field))
@@ -121,15 +154,21 @@ fn generate_initializer(name: &Ident, data: &Data) -> (TokenStream, Option<Token
                             })?
                     };
 
-                    quote! {
+                    names.push(quote! {
                         #field: #initializer,
-                    }
-                });
+                    });
+                }
 
                 let initializer = quote! {
                     mlua::Value::Table(table) => Ok(#name {
                         #(#names)*
                     })
+                };
+
+                let default_initializers = if impl_default {
+                    Some(quote! { #(#defaults)* })
+                } else {
+                    None
                 };
 
                 let handle_deprecated = if deprecated_field_handlers.is_empty() {
@@ -144,7 +183,7 @@ fn generate_initializer(name: &Ident, data: &Data) -> (TokenStream, Option<Token
                     })
                 };
 
-                (initializer, handle_deprecated)
+                (initializer, handle_deprecated, default_initializers)
             }
             syn::Fields::Unnamed(_) | syn::Fields::Unit => unimplemented!(),
         },
@@ -215,13 +254,14 @@ fn generate_initializer(name: &Ident, data: &Data) -> (TokenStream, Option<Token
                 }
             };
 
-            (initializer, None)
+            (initializer, None, None)
         }
         Data::Union(_) => unimplemented!(),
     }
 }
 
 struct StructAttributes {
+    impl_default: Option<TokenStream>,
     validate: Option<TokenStream>,
 }
 
@@ -229,6 +269,7 @@ fn get_struct_attributes(attributes: &Vec<Attribute>) -> StructAttributes {
     let mut attributes = parse_attributes("mlua", attributes);
 
     StructAttributes {
+        impl_default: get_attribute_with_default_value(&mut attributes, "impl_default", quote! {}),
         validate: get_attribute(&mut attributes, "validate"),
     }
 }

--- a/omni-led-lib/Cargo.toml
+++ b/omni-led-lib/Cargo.toml
@@ -12,6 +12,7 @@ dirs-next = "2.0"
 font-kit = "0.14"
 freetype-rs = "0.36"
 hidapi = "2.6"
+humantime = "2.3"
 image = "0.25"
 lazy_static = "1.4"
 log = { version = "0.4", features = ["std"] }

--- a/omni-led-lib/src/common/lua_register.rs
+++ b/omni-led-lib/src/common/lua_register.rs
@@ -5,7 +5,9 @@ use crate::{
     devices::device::MemoryLayout,
     logging::logger::LevelFilter,
     renderer::font_selector::{FamilyName, FontSelector, Stretch, Style, Weight},
-    script_handler::script_data_types::{EventKey, FontSize, ImageFormat, Regex, Repeat, Widget},
+    script_handler::script_data_types::{
+        DurationWrapper, EventKey, FontSize, ImageFormat, Regex, Repeat, Widget,
+    },
 };
 
 pub fn set_lua_enums(lua: &Lua, env: &Table) {
@@ -24,5 +26,6 @@ pub fn set_lua_enums(lua: &Lua, env: &Table) {
 }
 
 pub fn set_lua_types(lua: &Lua, env: &Table) {
+    DurationWrapper::register_members(lua, env).unwrap();
     Regex::register_members(lua, env).unwrap();
 }

--- a/omni-led-lib/src/common/lua_register.rs
+++ b/omni-led-lib/src/common/lua_register.rs
@@ -1,7 +1,7 @@
 use mlua::{Lua, Table};
 
 use crate::{
-    common::lua_traits::LuaConstructor,
+    common::lua_traits::LuaTypeStaticMembers,
     devices::device::MemoryLayout,
     logging::logger::LevelFilter,
     renderer::font_selector::{FamilyName, FontSelector, Stretch, Style, Weight},
@@ -24,5 +24,5 @@ pub fn set_lua_enums(lua: &Lua, env: &Table) {
 }
 
 pub fn set_lua_types(lua: &Lua, env: &Table) {
-    Regex::register_constructor(lua, env).unwrap();
+    Regex::register_members(lua, env).unwrap();
 }

--- a/omni-led-lib/src/common/lua_traits.rs
+++ b/omni-led-lib/src/common/lua_traits.rs
@@ -1,18 +1,46 @@
-use mlua::{FromLuaMulti, Lua, Table, UserData, Value};
+use mlua::{FromLuaMulti, IntoLua, IntoLuaMulti, Lua, Table, UserData, Value};
 
 pub trait LuaName {
     const NAME: &str;
 }
 
-pub trait LuaConstructor: UserData + LuaName + 'static {
-    type Args: FromLuaMulti;
+pub trait LuaTypeStaticMembers: UserData + LuaName + 'static {
+    fn add_members(functions: &mut StaticMembers<'_>);
 
-    fn constructor(lua: &Lua, args: Self::Args) -> mlua::Result<Self>;
+    fn register_members(lua: &Lua, env: &Table) -> mlua::Result<()> {
+        let mut members = StaticMembers {
+            lua,
+            members: Vec::new(),
+        };
+        Self::add_members(&mut members);
 
-    fn register_constructor(lua: &Lua, env: &Table) -> mlua::Result<()> {
         let table = lua.create_table()?;
-        table.set("new", lua.create_function(Self::constructor)?)?;
+        for (name, member) in members.members {
+            table.set(name, member)?;
+        }
         env.set(Self::NAME, table)
+    }
+}
+
+pub struct StaticMembers<'a> {
+    lua: &'a Lua,
+    members: Vec<(String, Value)>,
+}
+
+impl<'a> StaticMembers<'a> {
+    pub fn add_function<F, A, R>(&mut self, name: impl Into<String>, function: F)
+    where
+        F: Fn(&Lua, A) -> mlua::Result<R> + 'static,
+        A: FromLuaMulti,
+        R: IntoLuaMulti,
+    {
+        let function = self.lua.create_function(function).unwrap();
+        self.add_member(name, function);
+    }
+
+    pub fn add_member(&mut self, name: impl Into<String>, value: impl IntoLua) {
+        self.members
+            .push((name.into(), value.into_lua(self.lua).unwrap()));
     }
 }
 

--- a/omni-led-lib/src/script_handler/script_data_types.rs
+++ b/omni-led-lib/src/script_handler/script_data_types.rs
@@ -1,6 +1,8 @@
-use mlua::{ErrorContext, FromLua, Lua, UserData, UserDataFields, UserDataMethods, Value};
+use mlua::{
+    ErrorContext, FromLua, Lua, MetaMethod, UserData, UserDataFields, UserDataMethods, Value,
+};
 use omni_led_derive::{FromLuaValue, LuaEnum};
-use std::hash::Hash;
+use std::{hash::Hash, time::Duration};
 
 use crate::common::lua_traits::{FromUserdata, LuaName, LuaTypeStaticMembers, StaticMembers};
 
@@ -249,8 +251,8 @@ impl LuaName for Regex {
 }
 
 impl LuaTypeStaticMembers for Regex {
-    fn add_members(members: &mut StaticMembers<'_>) {
-        members.add_function("new", |_, re: String| Regex::new(&re))
+    fn add_members(functions: &mut StaticMembers<'_>) {
+        functions.add_function("new", |_, re: String| Regex::new(&re))
     }
 }
 
@@ -292,5 +294,83 @@ impl UserData for EventKey {
         methods.add_method("matches", |_, this, string: String| {
             Ok(this.matches(&string))
         });
+    }
+}
+
+#[derive(Clone)]
+pub struct DurationWrapper(pub Duration);
+
+impl DurationWrapper {
+    pub fn transform(wrapper: Self, _: &Lua) -> mlua::Result<Duration> {
+        Ok(wrapper.0)
+    }
+}
+
+impl LuaName for DurationWrapper {
+    const NAME: &str = "Duration";
+}
+
+impl LuaTypeStaticMembers for DurationWrapper {
+    fn add_members(members: &mut StaticMembers<'_>) {
+        macro_rules! construct {
+            ($from:ident) => {
+                members.add_function(stringify!($from), |_, value: u64| {
+                    Ok(DurationWrapper(Duration::$from(value)))
+                })
+            };
+        }
+
+        construct!(from_nanos);
+        construct!(from_micros);
+        construct!(from_millis);
+        construct!(from_secs);
+        construct!(from_mins);
+        construct!(from_hours);
+
+        members.add_member("MAX", DurationWrapper(Duration::MAX));
+        members.add_member("ZERO", DurationWrapper(Duration::ZERO));
+    }
+}
+
+impl UserData for DurationWrapper {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        macro_rules! get {
+            ($getter:ident) => {
+                methods.add_method(stringify!($getter), |_, this, _: ()| Ok(this.0.$getter()))
+            };
+        }
+        macro_rules! comparison {
+            ($meta:expr, $op:tt) => {
+                methods.add_meta_function(
+                    $meta,
+                    |_, (lhs, rhs): (Self, Self)| Ok(lhs.0 $op rhs.0),
+                )
+            };
+        }
+
+        get!(as_nanos);
+        get!(as_micros);
+        get!(as_millis);
+        get!(as_secs);
+        comparison!(MetaMethod::Lt, <);
+        comparison!(MetaMethod::Le, <=);
+        comparison!(MetaMethod::Eq, ==);
+        methods.add_meta_function(MetaMethod::Add, |_, (lhs, rhs): (Self, Self)| {
+            Ok(Self(lhs.0.saturating_add(rhs.0)))
+        });
+        methods.add_meta_function(MetaMethod::Sub, |_, (lhs, rhs): (Self, Self)| {
+            Ok(Self(lhs.0.saturating_sub(rhs.0)))
+        });
+        methods.add_meta_method(MetaMethod::ToString, |_, this, _: ()| {
+            Ok(format!("{:#?}", this.0))
+        });
+    }
+}
+
+impl FromUserdata for DurationWrapper {}
+
+impl FromLua for DurationWrapper {
+    fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+        Self::from_userdata(lua, value)
     }
 }

--- a/omni-led-lib/src/script_handler/script_data_types.rs
+++ b/omni-led-lib/src/script_handler/script_data_types.rs
@@ -362,7 +362,7 @@ impl UserData for DurationWrapper {
             Ok(Self(lhs.0.saturating_sub(rhs.0)))
         });
         methods.add_meta_method(MetaMethod::ToString, |_, this, _: ()| {
-            Ok(format!("{:#?}", this.0))
+            Ok(humantime::format_duration(this.0).to_string())
         });
     }
 }

--- a/omni-led-lib/src/script_handler/script_data_types.rs
+++ b/omni-led-lib/src/script_handler/script_data_types.rs
@@ -2,7 +2,7 @@ use mlua::{ErrorContext, FromLua, Lua, UserData, UserDataFields, UserDataMethods
 use omni_led_derive::{FromLuaValue, LuaEnum};
 use std::hash::Hash;
 
-use crate::common::lua_traits::{FromUserdata, LuaConstructor, LuaName};
+use crate::common::lua_traits::{FromUserdata, LuaName, LuaTypeStaticMembers, StaticMembers};
 
 #[derive(Debug, Clone, Copy, FromLuaValue)]
 pub struct Point {
@@ -248,11 +248,9 @@ impl LuaName for Regex {
     const NAME: &str = "Regex";
 }
 
-impl LuaConstructor for Regex {
-    type Args = String;
-
-    fn constructor(_lua: &Lua, re: Self::Args) -> mlua::Result<Self> {
-        Regex::new(&re)
+impl LuaTypeStaticMembers for Regex {
+    fn add_members(members: &mut StaticMembers<'_>) {
+        members.add_function("new", |_, re: String| Regex::new(&re))
     }
 }
 

--- a/omni-led-lib/src/script_handler/script_handler.rs
+++ b/omni-led-lib/src/script_handler/script_handler.rs
@@ -18,7 +18,7 @@ use crate::events::shortcuts::Shortcuts;
 use crate::renderer::animation::State;
 use crate::renderer::animation_group::AnimationGroup;
 use crate::renderer::renderer::Renderer;
-use crate::script_handler::script_data_types::{EventKey, Regex, Widget};
+use crate::script_handler::script_data_types::{DurationWrapper, EventKey, Regex, Widget};
 
 #[derive(UniqueUserData)]
 pub struct ScriptHandler {
@@ -336,9 +336,9 @@ struct LayoutData {
 }
 
 impl LayoutData {
-    fn transform_duration(duration: Option<u64>, _lua: &Lua) -> mlua::Result<Duration> {
+    fn transform_duration(duration: Option<DurationWrapper>, _lua: &Lua) -> mlua::Result<Duration> {
         let duration = duration
-            .and_then(|duration| Some(Duration::from_millis(duration)))
+            .and_then(|duration| Some(duration.0))
             .unwrap_or(DEFAULT_UPDATE_TIME);
         Ok(duration)
     }

--- a/omni-led-lib/src/settings/settings.rs
+++ b/omni-led-lib/src/settings/settings.rs
@@ -8,6 +8,7 @@ use crate::constants::config::{ConfigType, load_config};
 use crate::create_table_with_defaults;
 use crate::logging::logger::{LevelFilter, Log};
 use crate::renderer::font_selector::FontSelector;
+use crate::script_handler::script_data_types::DurationWrapper;
 
 #[derive(Debug, Clone, UniqueUserData, FromLuaValue)]
 pub struct Settings {
@@ -32,7 +33,7 @@ pub struct Settings {
     #[mlua(default = 0)]
     pub server_port: u16,
 
-    #[mlua(transform = Self::from_millis)]
+    #[mlua(transform = DurationWrapper::transform)]
     #[mlua(default = Duration::from_millis(100))]
     pub update_interval: Duration,
 }
@@ -58,10 +59,6 @@ impl Settings {
         logger.get().set_level_filter(settings.get().log_level);
 
         debug!("Loaded settings {:?}", settings.get());
-    }
-
-    fn from_millis(millis: u64, _: &Lua) -> mlua::Result<Duration> {
-        Ok(Duration::from_millis(millis))
     }
 }
 


### PR DESCRIPTION
New features:
- `Duration` type in scripts allows for creation and simple arithmetic of durations
- `system` application now supports selecting temperature unit

Breaking changes:
- Duration in scripts are now strongly typed using `Duration` type instead raw integers
- Duration in application arguments are now strongly typed using humantime duration strings