### PR TITLE
Fix missing global objects

### DIFF
--- a/omni-led-lib/src/script_handler/script_handler.rs
+++ b/omni-led-lib/src/script_handler/script_handler.rs
@@ -279,10 +279,10 @@ impl ScriptHandler {
             .unwrap();
 
         create_table_with_defaults!(lua, {
-            EVENTS = EVENTS,
-            LOG = LOG,
+            Events = Events,
+            Log = Log,
             PLATFORM = PLATFORM,
-            SHORTCUTS = SHORTCUTS,
+            Shortcuts = Shortcuts,
             PREDICATE = {
                 Always = $always_fn,
                 Never = $never_fn,


### PR DESCRIPTION
Re-add missing `Events`, `Log` and `Shortcuts` objects to the script environment.