### PR TITLE
Made the tray icon with static ID

### DIFF
--- a/omni-led-lib/src/ui/tray_icon.rs
+++ b/omni-led-lib/src/ui/tray_icon.rs
@@ -71,6 +71,7 @@ impl TrayIcon {
         }));
 
         let tray = TrayIconBuilder::new()
+            .with_id("com.github.llMBQll.OmniLED")
             .with_menu(Box::new(menu))
             .with_tooltip(TITLE)
             .with_icon(tray_icon_image())


### PR DESCRIPTION
Set the ID for the ray icon so that KDE (and possibly others) remember the tray icon properties, such as being hidden.

Linked to #74 