### PR TITLE
Allow reading and changing settings at runtime

### DIFF
--- a/config/settings.lua
+++ b/config/settings.lua
@@ -1,9 +1,7 @@
-Settings {
-    animation_ticks_delay = 8,
-    animation_ticks_rate = 2,
-    font = FontSelector.Default,
-    log_level = LevelFilter.Debug,
-    keyboard_ticks_repeat_delay = 2,
-    keyboard_ticks_repeat_rate = 2,
-    update_interval = Duration.from_millis(100),
-}
+Settings.animation_ticks_delay = 8
+Settings.animation_ticks_rate = 2
+Settings.font = FontSelector.Default
+Settings.log_level = LevelFilter.Debug
+Settings.keyboard_ticks_repeat_delay = 2
+Settings.keyboard_ticks_repeat_rate = 2
+Settings.update_interval = Duration.from_millis(100)

--- a/omni-led-lib/src/devices/devices.rs
+++ b/omni-led-lib/src/devices/devices.rs
@@ -83,6 +83,7 @@ impl Devices {
         let env = create_table_with_defaults!(lua, {
             Log = Log,
             PLATFORM = PLATFORM,
+            Settings = Settings,
         });
 
         let loaders = [

--- a/omni-led-lib/src/events/event_loop.rs
+++ b/omni-led-lib/src/events/event_loop.rs
@@ -1,8 +1,11 @@
 use log::trace;
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::events::event_queue::{Event, EventQueue};
+use crate::script_handler::script_data_types::DurationWrapper;
 
 pub struct EventLoop {}
 
@@ -11,19 +14,20 @@ impl EventLoop {
         Self {}
     }
 
-    pub fn run<F: FnMut(Vec<Event>)>(
+    pub fn run<F: FnMut(Duration, Vec<Event>)>(
         &self,
-        interval: Duration,
+        interval: Rc<RefCell<DurationWrapper>>,
         running: &AtomicBool,
         mut handler: F,
     ) {
         while running.load(Ordering::Relaxed) {
             let begin = Instant::now();
+            let interval = (*interval.borrow()).0;
 
             let event_queue = EventQueue::instance();
             let events = event_queue.lock().unwrap().get_events();
 
-            handler(events);
+            handler(interval, events);
 
             let end = Instant::now();
             let update_duration = end - begin;

--- a/omni-led-lib/src/events/shortcuts.rs
+++ b/omni-led-lib/src/events/shortcuts.rs
@@ -14,16 +14,16 @@ use crate::settings::settings::Settings;
 
 #[derive(LuaName)]
 pub struct Shortcuts {
-    delay: usize,
-    rate: usize,
+    delay: Rc<RefCell<usize>>,
+    rate: Rc<RefCell<usize>>,
     current_tick: Rc<RefCell<usize>>,
 }
 
 impl Shortcuts {
     pub fn load(lua: &Lua) {
         let settings = UserDataRef::<Settings>::load(lua);
-        let delay = settings.get().keyboard_ticks_repeat_delay;
-        let rate = settings.get().keyboard_ticks_repeat_rate;
+        let delay = settings.get().keyboard_ticks_repeat_delay.clone();
+        let rate = settings.get().keyboard_ticks_repeat_rate.clone();
         let current_tick = Rc::new(RefCell::new(0));
 
         let function = lua
@@ -66,8 +66,8 @@ impl Shortcuts {
         let press = all_pressed && !entry.last_all_pressed;
         let hold = all_pressed && entry.last_all_pressed;
         let required_ticks = match entry.hold_updates {
-            0 => entry.delay,
-            _ => entry.rate,
+            0 => *entry.delay.borrow(),
+            _ => *entry.rate.borrow(),
         };
         let delta_ticks = current_tick - entry.last_update_tick;
         let update = (current_tick != entry.last_update_tick)
@@ -140,8 +140,8 @@ impl Shortcuts {
             last_all_pressed: false,
             last_update_tick: 0,
             hold_updates: 0,
-            delay: self.delay,
-            rate: self.rate,
+            delay: self.delay.clone(),
+            rate: self.rate.clone(),
         };
 
         let current_tick = Rc::clone(&self.current_tick);
@@ -176,8 +176,8 @@ struct ShortcutEntry {
     last_all_pressed: bool,
     last_update_tick: usize,
     hold_updates: usize,
-    delay: usize,
-    rate: usize,
+    delay: Rc<RefCell<usize>>,
+    rate: Rc<RefCell<usize>>,
 }
 
 struct KeyState {

--- a/omni-led-lib/src/logging/logger.rs
+++ b/omni-led-lib/src/logging/logger.rs
@@ -2,7 +2,8 @@ use log::{debug, error, info, trace, warn};
 use mlua::{Lua, UserData, UserDataMethods};
 use omni_led_derive::{LuaEnum, LuaName};
 
-use crate::common::user_data::set_unique_user_data;
+use crate::common::user_data::{UserDataRef, set_unique_user_data};
+use crate::settings::settings::Settings;
 
 pub trait LogHandle {
     fn set_level_filter(&self, level_filter: log::LevelFilter);
@@ -21,6 +22,11 @@ impl Log {
                 handle: Box::new(handle),
             },
         );
+
+        Settings::on_log_level_update(lua, |lua, new_level_filter| {
+            let logger = UserDataRef::<Log>::load(lua);
+            logger.get().set_level_filter(new_level_filter);
+        });
     }
 
     pub fn set_level_filter(&self, level_filter: LevelFilter) {

--- a/omni-led-lib/src/plugin_loader/plugin_loader.rs
+++ b/omni-led-lib/src/plugin_loader/plugin_loader.rs
@@ -48,6 +48,7 @@ impl PluginLoader {
             get_default_plugin_path = $get_default_plugin_path_fn,
             Log = Log,
             PLATFORM = PLATFORM,
+            Settings = Settings,
         });
 
         load_config(lua, ConfigType::Plugins, &config, env).unwrap();

--- a/omni-led-lib/src/renderer/renderer.rs
+++ b/omni-led-lib/src/renderer/renderer.rs
@@ -1,8 +1,10 @@
 use mlua::Lua;
 use num_traits::clamp;
+use std::cell::RefCell;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::rc::Rc;
 use std::str::Chars;
 
 use crate::common::user_data::UserDataRef;
@@ -20,14 +22,14 @@ use crate::settings::settings::Settings;
 
 macro_rules! get_animation_settings {
     ($default:expr, $widget:expr) => {
-        AnimationSettings {
-            ticks_at_edge: $widget
+        (
+            $widget
                 .animation_ticks_delay
-                .unwrap_or($default.ticks_at_edge),
-            ticks_per_move: $widget
+                .unwrap_or(*$default.ticks_at_edge.borrow()),
+            $widget
                 .animation_ticks_rate
-                .unwrap_or($default.ticks_per_move),
-        }
+                .unwrap_or(*$default.ticks_per_move.borrow()),
+        )
     };
 }
 
@@ -40,7 +42,7 @@ pub struct Renderer {
 impl Renderer {
     pub fn new(lua: &Lua) -> Self {
         let settings = UserDataRef::<Settings>::load(lua);
-        let font_selector = settings.get().font.clone();
+        let font_selector = settings.get().font.borrow().clone();
 
         Self {
             font_manager: FontManager::new(font_selector),
@@ -264,7 +266,8 @@ impl Renderer {
 
                     let group = Self::get_animation_group(animation_groups, image.animation_group);
                     group.entry(image.image.hash.unwrap()).or_insert_with(|| {
-                        let settings = get_animation_settings!(self.animation_settings, image);
+                        let (ticks_at_edge, ticks_per_move) =
+                            get_animation_settings!(self.animation_settings, image);
                         let rendered = images::render_image(
                             &mut self.image_cache,
                             &image.image,
@@ -272,12 +275,7 @@ impl Renderer {
                             image.threshold,
                             image.animated,
                         );
-                        Animation::new(
-                            settings.ticks_at_edge,
-                            settings.ticks_per_move,
-                            rendered.len(),
-                            image.repeats,
-                        )
+                        Animation::new(ticks_at_edge, ticks_per_move, rendered.len(), image.repeats)
                     });
                 }
                 Widget::Text(text) => {
@@ -289,14 +287,10 @@ impl Renderer {
 
                     let group = Self::get_animation_group(animation_groups, text.animation_group);
                     group.entry(text.hash.unwrap()).or_insert_with(|| {
-                        let settings = get_animation_settings!(self.animation_settings, text);
+                        let (ticks_at_edge, ticks_per_move) =
+                            get_animation_settings!(self.animation_settings, text);
                         let steps = Self::pre_render_text(&mut self.font_manager, text);
-                        Animation::new(
-                            settings.ticks_at_edge,
-                            settings.ticks_per_move,
-                            steps,
-                            text.repeats,
-                        )
+                        Animation::new(ticks_at_edge, ticks_per_move, steps, text.repeats)
                     });
                 }
             };
@@ -374,16 +368,16 @@ impl Renderer {
 }
 
 struct AnimationSettings {
-    ticks_at_edge: usize,
-    ticks_per_move: usize,
+    ticks_at_edge: Rc<RefCell<usize>>,
+    ticks_per_move: Rc<RefCell<usize>>,
 }
 
 impl AnimationSettings {
     pub fn new(lua: &Lua) -> Self {
         let settings = UserDataRef::<Settings>::load(lua);
         Self {
-            ticks_at_edge: settings.get().animation_ticks_delay,
-            ticks_per_move: settings.get().animation_ticks_rate,
+            ticks_at_edge: settings.get().animation_ticks_delay.clone(),
+            ticks_per_move: settings.get().animation_ticks_rate.clone(),
         }
     }
 }

--- a/omni-led-lib/src/script_handler/script_data_types.rs
+++ b/omni-led-lib/src/script_handler/script_data_types.rs
@@ -291,7 +291,7 @@ impl UserData for EventKey {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DurationWrapper(pub Duration);
 
 impl DurationWrapper {

--- a/omni-led-lib/src/script_handler/script_handler.rs
+++ b/omni-led-lib/src/script_handler/script_handler.rs
@@ -282,12 +282,13 @@ impl ScriptHandler {
             Events = Events,
             Log = Log,
             PLATFORM = PLATFORM,
-            Shortcuts = Shortcuts,
             PREDICATE = {
                 Always = $always_fn,
                 Never = $never_fn,
                 Times = $times_fn,
-            }
+            },
+            Settings = Settings,
+            Shortcuts = Shortcuts,
         })
     }
 }

--- a/omni-led-lib/src/settings/settings.rs
+++ b/omni-led-lib/src/settings/settings.rs
@@ -9,10 +9,12 @@ use crate::common::user_data::{UserDataRef, set_unique_user_data};
 use crate::constants::config::{ConfigType, load_config};
 use crate::create_table_with_defaults;
 use crate::events::event_queue::{Event, EventQueue};
+use crate::events::events::Events;
 use crate::events::events::ScriptEvent;
 use crate::logging::logger::{LevelFilter, Log};
 use crate::renderer::font_selector::FontSelector;
 use crate::script_handler::script_data_types::DurationWrapper;
+use crate::script_handler::script_data_types::EventKey;
 
 #[derive(Debug, Clone)]
 pub struct Settings {
@@ -58,6 +60,25 @@ impl Default for Settings {
             update_interval: Rc::new(RefCell::new(DurationWrapper(Duration::from_millis(100)))),
         }
     }
+}
+
+macro_rules! make_register_fn {
+    ($fn_name:ident, $name:ident, $ty:ty) => {
+        pub fn $fn_name<F: Fn(&Lua, $ty) + 'static>(lua: &Lua, callback: F) {
+            let key = EventKey::String(format!("Settings.{}", stringify!($name)));
+            let callback = lua
+                .create_function(move |lua, (_event, val): (String, $ty)| {
+                    callback(lua, val);
+                    Ok(())
+                })
+                .unwrap();
+            Events::register(key, callback, true);
+        }
+    };
+}
+
+impl Settings {
+    make_register_fn!(on_log_level_update, log_level, LevelFilter);
 }
 
 impl LuaName for Settings {

--- a/omni-led-lib/src/settings/settings.rs
+++ b/omni-led-lib/src/settings/settings.rs
@@ -1,6 +1,5 @@
 use log::debug;
 use mlua::{Lua, UserData, chunk};
-use omni_led_derive::FromLuaValue;
 use std::time::Duration;
 
 use crate::common::lua_traits::LuaName;
@@ -11,44 +10,26 @@ use crate::logging::logger::{LevelFilter, Log};
 use crate::renderer::font_selector::FontSelector;
 use crate::script_handler::script_data_types::DurationWrapper;
 
-#[derive(Debug, Clone, FromLuaValue)]
+#[derive(Debug, Clone, UserData)]
 pub struct Settings {
-    #[mlua(default = 8)]
     pub animation_ticks_delay: usize,
-
-    #[mlua(default = 2)]
     pub animation_ticks_rate: usize,
-
-    #[mlua(default = FontSelector::Default)]
     pub font: FontSelector,
-
-    #[mlua(default = LevelFilter::Info)]
     pub log_level: LevelFilter,
-
-    #[mlua(default = 2)]
     pub keyboard_ticks_repeat_delay: usize,
-
-    #[mlua(default = 2)]
     pub keyboard_ticks_repeat_rate: usize,
-
-    #[mlua(transform = DurationWrapper::transform)]
-    #[mlua(default = Duration::from_millis(100))]
+    #[lua(skip)]
     pub update_interval: Duration,
 }
 
 impl Settings {
     pub fn load(lua: &Lua, config: String) {
-        let load_settings_fn = lua
-            .create_function(move |lua, settings: Settings| {
-                set_unique_user_data(lua, settings);
-                Ok(())
-            })
-            .unwrap();
+        set_unique_user_data(lua, Settings::default());
 
         let env = create_table_with_defaults!(lua, {
             Log = Log,
             PLATFORM = PLATFORM,
-            Settings = $load_settings_fn,
+            Settings = Settings,
         });
         load_config(lua, ConfigType::Settings, &config, env).unwrap();
 
@@ -60,8 +41,33 @@ impl Settings {
     }
 }
 
-impl LuaName for Settings {
-    const NAME: &str = "SETTINGS";
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            animation_ticks_delay: 8,
+            animation_ticks_rate: 2,
+            font: FontSelector::Default,
+            log_level: LevelFilter::Info,
+            keyboard_ticks_repeat_delay: 2,
+            keyboard_ticks_repeat_rate: 2,
+            update_interval: Duration::from_millis(100),
+        }
+    }
 }
 
-impl UserData for Settings {}
+#[mlua::userdata_impl]
+impl Settings {
+    #[lua(getter, name = "update_interval", infallible)]
+    fn get_update_interval(&self) -> DurationWrapper {
+        DurationWrapper(self.update_interval)
+    }
+
+    #[lua(setter, name = "update_interval", infallible)]
+    fn set_update_interval(&mut self, update_interval: DurationWrapper) {
+        self.update_interval = update_interval.0;
+    }
+}
+
+impl LuaName for Settings {
+    const NAME: &str = "Settings";
+}

--- a/omni-led-lib/src/settings/settings.rs
+++ b/omni-led-lib/src/settings/settings.rs
@@ -1,16 +1,18 @@
 use log::debug;
-use mlua::{Lua, UserData, chunk};
+use mlua::{IntoLua, Lua, UserData, UserDataFields, chunk};
 use std::time::Duration;
 
 use crate::common::lua_traits::LuaName;
 use crate::common::user_data::{UserDataRef, set_unique_user_data};
 use crate::constants::config::{ConfigType, load_config};
 use crate::create_table_with_defaults;
+use crate::events::event_queue::{Event, EventQueue};
+use crate::events::events::ScriptEvent;
 use crate::logging::logger::{LevelFilter, Log};
 use crate::renderer::font_selector::FontSelector;
 use crate::script_handler::script_data_types::DurationWrapper;
 
-#[derive(Debug, Clone, UserData)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     pub animation_ticks_delay: usize,
     pub animation_ticks_rate: usize,
@@ -18,7 +20,6 @@ pub struct Settings {
     pub log_level: LevelFilter,
     pub keyboard_ticks_repeat_delay: usize,
     pub keyboard_ticks_repeat_rate: usize,
-    #[lua(skip)]
     pub update_interval: Duration,
 }
 
@@ -55,19 +56,48 @@ impl Default for Settings {
     }
 }
 
-#[mlua::userdata_impl]
-impl Settings {
-    #[lua(getter, name = "update_interval", infallible)]
-    fn get_update_interval(&self) -> DurationWrapper {
-        DurationWrapper(self.update_interval)
-    }
-
-    #[lua(setter, name = "update_interval", infallible)]
-    fn set_update_interval(&mut self, update_interval: DurationWrapper) {
-        self.update_interval = update_interval.0;
-    }
-}
-
 impl LuaName for Settings {
     const NAME: &str = "Settings";
+}
+
+macro_rules! get_set_impl {
+    ($fields:ident, $name:ident) => {
+        $fields.add_field_method_get(stringify!($name), |_, this| Ok(this.$name.clone()));
+        $fields.add_field_method_set(stringify!($name), |lua, this, val| {
+            this.$name = val;
+            EventQueue::instance()
+                .lock()
+                .unwrap()
+                .push(Event::Script(ScriptEvent {
+                    event: format!("Settings.{}", stringify!($name)),
+                    value: this.$name.clone().into_lua(&lua)?,
+                }));
+            Ok(())
+        });
+    };
+}
+
+impl UserData for Settings {
+    fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
+        get_set_impl!(fields, animation_ticks_delay);
+        get_set_impl!(fields, animation_ticks_rate);
+        get_set_impl!(fields, font);
+        get_set_impl!(fields, log_level);
+        get_set_impl!(fields, keyboard_ticks_repeat_delay);
+        get_set_impl!(fields, keyboard_ticks_repeat_rate);
+        fields.add_field_method_get("update_interval", |_, this| {
+            Ok(DurationWrapper(this.update_interval))
+        });
+        fields.add_field_method_set("update_interval", |lua, this, val: DurationWrapper| {
+            this.update_interval = val.0;
+            EventQueue::instance()
+                .lock()
+                .unwrap()
+                .push(Event::Script(ScriptEvent {
+                    event: "Settings.update_interval".to_string(),
+                    value: val.into_lua(&lua)?,
+                }));
+            Ok(())
+        });
+    }
 }

--- a/omni-led-lib/src/settings/settings.rs
+++ b/omni-led-lib/src/settings/settings.rs
@@ -1,5 +1,7 @@
 use log::debug;
 use mlua::{IntoLua, Lua, UserData, UserDataFields, chunk};
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::time::Duration;
 
 use crate::common::lua_traits::LuaName;
@@ -14,13 +16,13 @@ use crate::script_handler::script_data_types::DurationWrapper;
 
 #[derive(Debug, Clone)]
 pub struct Settings {
-    pub animation_ticks_delay: usize,
-    pub animation_ticks_rate: usize,
-    pub font: FontSelector,
-    pub log_level: LevelFilter,
-    pub keyboard_ticks_repeat_delay: usize,
-    pub keyboard_ticks_repeat_rate: usize,
-    pub update_interval: Duration,
+    pub animation_ticks_delay: Rc<RefCell<usize>>,
+    pub animation_ticks_rate: Rc<RefCell<usize>>,
+    pub font: Rc<RefCell<FontSelector>>,
+    pub log_level: Rc<RefCell<LevelFilter>>,
+    pub keyboard_ticks_repeat_delay: Rc<RefCell<usize>>,
+    pub keyboard_ticks_repeat_rate: Rc<RefCell<usize>>,
+    pub update_interval: Rc<RefCell<DurationWrapper>>,
 }
 
 impl Settings {
@@ -36,7 +38,9 @@ impl Settings {
 
         let settings = UserDataRef::<Settings>::load(lua);
         let logger = UserDataRef::<Log>::load(lua);
-        logger.get().set_level_filter(settings.get().log_level);
+        logger
+            .get()
+            .set_level_filter(*settings.get().log_level.borrow());
 
         debug!("Loaded settings {:?}", settings.get());
     }
@@ -45,13 +49,13 @@ impl Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            animation_ticks_delay: 8,
-            animation_ticks_rate: 2,
-            font: FontSelector::Default,
-            log_level: LevelFilter::Info,
-            keyboard_ticks_repeat_delay: 2,
-            keyboard_ticks_repeat_rate: 2,
-            update_interval: Duration::from_millis(100),
+            animation_ticks_delay: Rc::new(RefCell::new(8)),
+            animation_ticks_rate: Rc::new(RefCell::new(2)),
+            font: Rc::new(RefCell::new(FontSelector::Default)),
+            log_level: Rc::new(RefCell::new(LevelFilter::Info)),
+            keyboard_ticks_repeat_delay: Rc::new(RefCell::new(2)),
+            keyboard_ticks_repeat_rate: Rc::new(RefCell::new(2)),
+            update_interval: Rc::new(RefCell::new(DurationWrapper(Duration::from_millis(100)))),
         }
     }
 }
@@ -62,15 +66,17 @@ impl LuaName for Settings {
 
 macro_rules! get_set_impl {
     ($fields:ident, $name:ident) => {
-        $fields.add_field_method_get(stringify!($name), |_, this| Ok(this.$name.clone()));
+        $fields.add_field_method_get(stringify!($name), |_, this| {
+            Ok((*this.$name.borrow()).clone())
+        });
         $fields.add_field_method_set(stringify!($name), |lua, this, val| {
-            this.$name = val;
+            *this.$name.borrow_mut() = val;
             EventQueue::instance()
                 .lock()
                 .unwrap()
                 .push(Event::Script(ScriptEvent {
                     event: format!("Settings.{}", stringify!($name)),
-                    value: this.$name.clone().into_lua(&lua)?,
+                    value: (*this.$name.borrow()).clone().into_lua(&lua)?,
                 }));
             Ok(())
         });
@@ -85,19 +91,6 @@ impl UserData for Settings {
         get_set_impl!(fields, log_level);
         get_set_impl!(fields, keyboard_ticks_repeat_delay);
         get_set_impl!(fields, keyboard_ticks_repeat_rate);
-        fields.add_field_method_get("update_interval", |_, this| {
-            Ok(DurationWrapper(this.update_interval))
-        });
-        fields.add_field_method_set("update_interval", |lua, this, val: DurationWrapper| {
-            this.update_interval = val.0;
-            EventQueue::instance()
-                .lock()
-                .unwrap()
-                .push(Event::Script(ScriptEvent {
-                    event: "Settings.update_interval".to_string(),
-                    value: val.into_lua(&lua)?,
-                }));
-            Ok(())
-        });
+        get_set_impl!(fields, update_interval);
     }
 }

--- a/omni-led/src/main.rs
+++ b/omni-led/src/main.rs
@@ -85,9 +85,9 @@ fn main() {
         debug!("Initialized in {:?}", init_end - init_begin);
 
         let settings = UserDataRef::<Settings>::load(&lua);
-        let interval = settings.get().update_interval;
+        let interval = settings.get().update_interval.clone();
         let event_loop = EventLoop::new();
-        event_loop.run(interval, &RUNNING, |events| {
+        event_loop.run(interval, &RUNNING, |interval, events| {
             for event in events {
                 dispatcher.dispatch(&lua, event).unwrap();
             }


### PR DESCRIPTION
Changes:
- `Settings` object can now be accessed from all user scripts
- Settings can now be changed at runtime, and affect the program in real time
- [breaking] `config/settings.lua` now receives an existing `Settings` object that can be read from and written to, instead of just having a constructor function